### PR TITLE
Added remove and rescinfo RPCs

### DIFF
--- a/server/docs/RESOURCES.md
+++ b/server/docs/RESOURCES.md
@@ -1,0 +1,61 @@
+# Server Resources
+
+Data can be accessed on the server through resources. Resources are accessed by name and represent arbitrary data. Resources can be uploaded, removed, and downloaded. They are managed through the various [interfaces](#INTERFACES.md).
+
+## Authorities
+
+Resources are grouped into different authorities, each having different access privileges. The following authorities are available:
+
+| Authority | Description |
+| --------- | ----------- |
+| `public`  | Publicly accessible resources. |
+| `private` | Resources accessible only to the server. |
+| `session` | Resources associated with the current session. |
+
+### Public Resources
+
+Public resources are accessible to anyone and do not require authentication. Public resources are read-only.
+
+### Private Resources
+
+Private resources are innaccessible to anyone except the server. Any attempt by a client to access a private resource is not allowed.
+
+### Session Resources
+
+Session resources are accessible only to the current session. Session resources have read, write, and delete access. Session resources are automatically deleted when the session ends. Accessing these resources requires authentication. A session can be created with the [`login`](INTERFACES.md#login) interface.
+
+## Accessing Resources
+
+### Identifying Resources
+
+Resources are identified through the following form:
+
+```
+<authority>:<name>
+```
+
+Where `<authority>` is the authority name and `<name>` is the resource name. For example, the resource `public:foo` is a public resource named `foo`.
+
+Resource names cannot contain a `.` that precedes an entry in an abstract path. For example, the resource `session:.foo.txt` is invalid. The resource `session:foo/.bar/baz.txt` is also invalid.
+
+### Interfacing with Resources
+
+The following interfaces are available for accessing resources:
+
+- [`upload`](INTERFACES.md#upload) - Upload a resource.
+- [`fetch`](INTERFACES.md#fetch) - Download a resource.
+- [`delete`](INTERFACES.md#delete) - Delete a resource.
+
+### Errors
+
+Below is a description of some of the errors that can occur when accessing resources. An interface may have additional errors not listed here.
+
+| Code | Description |
+| ---- | ----------- |
+| `400 Bad Request` | The resource name is invalid or the request is malformed. |
+| `401 Unauthorized` | The client is attempting to access a session resource and is not authenticated. |
+| `403 Forbidden` | The client is attempting to access a private resource or does not have permission to perform the requested action. |
+| `404 Not Found` | The resource does not exist and the client is attempting to read or delete it. Also occurs if an unknown authority is specified. |
+| `406 Not Acceptable` | The client specified the `Accept` header and the requested resource exists, is accessible, but is not of the requested type. Also occurs if client specified the `Content-Type` header and the server does not support the specified type. The file extension is used to determine the type in the absence of the `Content-Type` header. |
+| `413 Payload Too Large` | The client is attempting to upload a resource that is too large or uploading the resource would cause the session to exceed its quota. |
+| `429 Too Many Requests` | The client is attempting to upload a resource too quickly. |

--- a/server/main/src/com/smartnote/server/Server.java
+++ b/server/main/src/com/smartnote/server/Server.java
@@ -11,6 +11,7 @@ import com.smartnote.server.api.v1.Export;
 import com.smartnote.server.api.v1.Fetch;
 import com.smartnote.server.api.v1.Generate;
 import com.smartnote.server.api.v1.Login;
+import com.smartnote.server.api.v1.Remove;
 import com.smartnote.server.api.v1.Upload;
 import com.smartnote.server.auth.SessionManager;
 import com.smartnote.server.cli.CommandLineParser;
@@ -195,6 +196,7 @@ public class Server {
         addRoute(Upload.class);
         addRoute(Login.class);
         addRoute(Upload.class);
+        addRoute(Remove.class);
 
         return 0;
     }

--- a/server/main/src/com/smartnote/server/Server.java
+++ b/server/main/src/com/smartnote/server/Server.java
@@ -12,6 +12,7 @@ import com.smartnote.server.api.v1.Fetch;
 import com.smartnote.server.api.v1.Generate;
 import com.smartnote.server.api.v1.Login;
 import com.smartnote.server.api.v1.Remove;
+import com.smartnote.server.api.v1.RescInfo;
 import com.smartnote.server.api.v1.Upload;
 import com.smartnote.server.auth.SessionManager;
 import com.smartnote.server.cli.CommandLineParser;
@@ -197,6 +198,7 @@ public class Server {
         addRoute(Login.class);
         addRoute(Upload.class);
         addRoute(Remove.class);
+        addRoute(RescInfo.class);
 
         return 0;
     }

--- a/server/main/src/com/smartnote/server/api/v1/Remove.java
+++ b/server/main/src/com/smartnote/server/api/v1/Remove.java
@@ -2,6 +2,15 @@ package com.smartnote.server.api.v1;
 
 import static spark.Spark.*;
 
+import java.io.IOException;
+import java.nio.file.InvalidPathException;
+
+import com.smartnote.server.Server;
+import com.smartnote.server.auth.Session;
+import com.smartnote.server.auth.SessionManager;
+import com.smartnote.server.resource.NoSuchResourceException;
+import com.smartnote.server.resource.Resource;
+import com.smartnote.server.resource.ResourceSystem;
 import com.smartnote.server.util.MethodType;
 import com.smartnote.server.util.ServerRoute;
 
@@ -9,13 +18,66 @@ import spark.Request;
 import spark.Response;
 import spark.Route;
 
+/**
+ * <p>Delete a file from the server.</p>
+ * 
+ * @author Ethan Vrhel
+ * @see com.smartnote.server.resource.Resource
+ */
 @ServerRoute(path = "/api/v1/remove", method = MethodType.POST)
 public class Remove implements Route {
 
     @Override
     public Object handle(Request request, Response response) throws Exception {
-        halt(501);
-        return null;
+        ResourceSystem system = Server.getServer().getResourceSystem();
+        SessionManager sessionManager = Server.getServer().getSessionManager();
+
+        Session session = sessionManager.getSession(request);
+        if (session == null) {
+            response.status(401);
+            return "{\"message\": \"No session\"}";
+        }
+
+        String filename = request.queryParams("name");
+        if (filename == null) {
+            response.status(400);
+            return "{\"message\": \"Name was not specified\"}";
+        }
+
+        // find resource
+        Resource resource;
+        String path = ResourceSystem.inSession(filename);
+        try {
+            resource = system.findResource(path, session.getPermission());
+        } catch (SecurityException e) {
+            response.status(403);
+            return "{\"message\": \"Access denied\"}";
+        } catch (InvalidPathException e) {
+            response.status(400);
+            return "{\"message\": \"Invalid path\"}";
+        } catch (NoSuchResourceException e) {
+            response.status(404);
+            return "{\"message\": \"Resource not found\"}";
+        } catch (IOException e) {
+            response.status(500);
+            return "{\"message\": \"Could open resource\"}";
+        }
+
+        // delete resource
+        try {
+            resource.delete();
+        } catch (SecurityException e) {
+            response.status(403);
+            return "{\"message\": \"Access denied\"}";
+        } catch (IOException e) {
+            response.status(500);
+            return "{\"message\": \"Could not delete resource\"}";
+        }
+
+        session.updateSession(sessionManager);
+        session.writeToResponse(response);
+
+        return "{\"message\":\"File deleted\"}";
     }
     
 }

--- a/server/main/src/com/smartnote/server/api/v1/Remove.java
+++ b/server/main/src/com/smartnote/server/api/v1/Remove.java
@@ -1,7 +1,5 @@
 package com.smartnote.server.api.v1;
 
-import static spark.Spark.*;
-
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
 

--- a/server/main/src/com/smartnote/server/api/v1/Remove.java
+++ b/server/main/src/com/smartnote/server/api/v1/Remove.java
@@ -1,0 +1,21 @@
+package com.smartnote.server.api.v1;
+
+import static spark.Spark.*;
+
+import com.smartnote.server.util.MethodType;
+import com.smartnote.server.util.ServerRoute;
+
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+@ServerRoute(path = "/api/v1/remove", method = MethodType.POST)
+public class Remove implements Route {
+
+    @Override
+    public Object handle(Request request, Response response) throws Exception {
+        halt(501);
+        return null;
+    }
+    
+}

--- a/server/main/src/com/smartnote/server/api/v1/Remove.java
+++ b/server/main/src/com/smartnote/server/api/v1/Remove.java
@@ -44,9 +44,8 @@ public class Remove implements Route {
 
         // find resource
         Resource resource;
-        String path = ResourceSystem.inSession(filename);
         try {
-            resource = system.findResource(path, session.getPermission());
+            resource = system.findResource(filename, session.getPermission());
         } catch (SecurityException e) {
             response.status(403);
             return "{\"message\": \"Access denied\"}";

--- a/server/main/src/com/smartnote/server/api/v1/Remove.java
+++ b/server/main/src/com/smartnote/server/api/v1/Remove.java
@@ -1,5 +1,6 @@
 package com.smartnote.server.api.v1;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
 
@@ -17,7 +18,9 @@ import spark.Response;
 import spark.Route;
 
 /**
- * <p>Delete a file from the server.</p>
+ * <p>
+ * Delete a file from the server.
+ * </p>
  * 
  * @author Ethan Vrhel
  * @see com.smartnote.server.resource.Resource
@@ -27,6 +30,8 @@ public class Remove implements Route {
 
     @Override
     public Object handle(Request request, Response response) throws Exception {
+        response.type("application/json");
+
         ResourceSystem system = Server.getServer().getResourceSystem();
         SessionManager sessionManager = Server.getServer().getSessionManager();
 
@@ -66,6 +71,9 @@ public class Remove implements Route {
         } catch (SecurityException e) {
             response.status(403);
             return "{\"message\": \"Access denied\"}";
+        } catch (FileNotFoundException e) {
+            response.status(404);
+            return "{\"message\": \"Resource not found\"}";
         } catch (IOException e) {
             response.status(500);
             return "{\"message\": \"Could not delete resource\"}";
@@ -76,5 +84,5 @@ public class Remove implements Route {
 
         return "{\"message\":\"File deleted\"}";
     }
-    
+
 }

--- a/server/main/src/com/smartnote/server/api/v1/RescInfo.java
+++ b/server/main/src/com/smartnote/server/api/v1/RescInfo.java
@@ -14,13 +14,15 @@ import spark.Response;
 import spark.Route;
 
 /**
- * <p>Provides information about the server's resource system.</p>
+ * <p>
+ * Provides information about the server's resource system.
+ * </p>
  * 
  * @author Ethan Vrhel
  * @see com.smartnote.server.resource.ResourceConfig
  * @see com.smartnote.server.resource.ResourceSystem
  */
-@ServerRoute(path = "/api/v1/rescinfo", method=MethodType.GET)
+@ServerRoute(path = "/api/v1/rescinfo", method = MethodType.GET)
 public class RescInfo implements Route {
 
     @Override
@@ -36,16 +38,18 @@ public class RescInfo implements Route {
         for (String type : ResourceSystem.SUPPORTED_MIME_TYPES)
             supportedTypes.add(type);
         obj.add("supportedTypes", supportedTypes);
-        
+
         JsonArray authorities = new JsonArray();
         for (String auth : ResourceSystem.AUTHORITIES)
             authorities.add(auth);
         obj.add("authorities", authorities);
+
+        obj.addProperty("message", "OK");
 
         Gson gson = new Gson();
         String json = gson.toJson(obj);
 
         return json;
     }
-    
+
 }

--- a/server/main/src/com/smartnote/server/api/v1/RescInfo.java
+++ b/server/main/src/com/smartnote/server/api/v1/RescInfo.java
@@ -1,0 +1,51 @@
+package com.smartnote.server.api.v1;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.smartnote.server.Server;
+import com.smartnote.server.resource.ResourceConfig;
+import com.smartnote.server.resource.ResourceSystem;
+import com.smartnote.server.util.MethodType;
+import com.smartnote.server.util.ServerRoute;
+
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+/**
+ * <p>Provides information about the server's resource system.</p>
+ * 
+ * @author Ethan Vrhel
+ * @see com.smartnote.server.resource.ResourceConfig
+ * @see com.smartnote.server.resource.ResourceSystem
+ */
+@ServerRoute(path = "/api/v1/rescinfo", method=MethodType.GET)
+public class RescInfo implements Route {
+
+    @Override
+    public Object handle(Request request, Response response) throws Exception {
+        ResourceConfig config = Server.getServer().getConfig().getResourceConfig();
+        response.type("application/json");
+
+        JsonObject obj = new JsonObject();
+        obj.addProperty("sessionQuota", config.getSessionQuota());
+        obj.addProperty("maxUploadSize", config.getMaxUploadSize());
+
+        JsonArray supportedTypes = new JsonArray();
+        for (String type : ResourceSystem.SUPPORTED_MIME_TYPES)
+            supportedTypes.add(type);
+        obj.add("supportedTypes", supportedTypes);
+        
+        JsonArray authorities = new JsonArray();
+        for (String auth : ResourceSystem.AUTHORITIES)
+            authorities.add(auth);
+        obj.add("authorities", authorities);
+
+        Gson gson = new Gson();
+        String json = gson.toJson(obj);
+
+        return json;
+    }
+    
+}

--- a/server/main/src/com/smartnote/server/api/v1/Upload.java
+++ b/server/main/src/com/smartnote/server/api/v1/Upload.java
@@ -5,6 +5,8 @@ import java.io.OutputStream;
 import java.nio.file.InvalidPathException;
 import java.security.Permission;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.smartnote.server.Server;
 import com.smartnote.server.auth.Session;
 import com.smartnote.server.auth.SessionManager;
@@ -129,6 +131,10 @@ public class Upload implements Route {
         session.updateSession(sessionManager);
         session.writeToResponse(response);
 
-        return String.format("{\"message\":\"File uploaded\",\"name\":\"%s\"}", path);
+        JsonObject obj = new JsonObject();
+        obj.addProperty("message", "File uploaded");
+        obj.addProperty("name", system.getActualPath(path));
+
+        return new Gson().toJson(obj);
     }
 }

--- a/server/main/src/com/smartnote/server/api/v1/Upload.java
+++ b/server/main/src/com/smartnote/server/api/v1/Upload.java
@@ -129,6 +129,6 @@ public class Upload implements Route {
         session.updateSession(sessionManager);
         session.writeToResponse(response);
 
-        return String.format("{\"message\":\"File was uploaded\",\"name\":\"%s\"}", path);
+        return String.format("{\"message\":\"File uploaded\",\"name\":\"%s\"}", path);
     }
 }

--- a/server/main/src/com/smartnote/server/auth/Session.java
+++ b/server/main/src/com/smartnote/server/auth/Session.java
@@ -170,6 +170,17 @@ public class Session {
         return new SessionPermission(this);
     }
 
+    /**
+     * Gets the amount of storage used by this session. Note that this
+     * recalculates the size of the session directory every time it is
+     * called.
+     * 
+     * @return The quota used.
+     */
+    public long getStorageUsage() {
+        return FileUtils.getDirectorySize(sessionDirectory.toFile());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof Session))

--- a/server/main/src/com/smartnote/server/resource/FileResource.java
+++ b/server/main/src/com/smartnote/server/resource/FileResource.java
@@ -31,7 +31,7 @@ class FileResource implements Resource {
      */
     FileResource(File file, AccessMode mode) {
         this.file = Objects.requireNonNull(file, "file must not be null");
-        this.mode = mode;
+        this.mode = Objects.requireNonNull(mode, "mode must not be null");
     }
 
     @Override

--- a/server/main/src/com/smartnote/server/resource/FileResource.java
+++ b/server/main/src/com/smartnote/server/resource/FileResource.java
@@ -9,6 +9,8 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.Objects;
 
+import com.smartnote.server.util.FileUtils;
+
 /**
  * <p>
  * Represents a file resource.
@@ -57,5 +59,16 @@ class FileResource implements Resource {
         if (!mode.hasDelete())
             throw new SecurityException("No delete permission");
         file.delete();
+    }
+
+    @Override
+    public long size() throws SecurityException, IOException {
+        if (!mode.hasRead())
+            throw new SecurityException("No read permission");
+
+        if (file.isDirectory())
+            return FileUtils.getDirectorySize(file);
+            
+        return file.length();
     }
 }

--- a/server/main/src/com/smartnote/server/resource/FileResource.java
+++ b/server/main/src/com/smartnote/server/resource/FileResource.java
@@ -2,6 +2,7 @@ package com.smartnote.server.resource;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,6 +39,8 @@ class FileResource implements Resource {
     public InputStream openInputStream() throws SecurityException, IOException {
         if (!mode.hasRead())
             throw new SecurityException("No read permission");
+        if (!file.exists())
+            throw new FileNotFoundException("File does not exist");
         return new FileInputStream(file);
     }
 
@@ -58,6 +61,8 @@ class FileResource implements Resource {
     public void delete() throws SecurityException, IOException {
         if (!mode.hasDelete())
             throw new SecurityException("No delete permission");
+        if (!file.exists())
+            throw new FileNotFoundException("File does not exist");
         file.delete();
     }
 
@@ -66,9 +71,12 @@ class FileResource implements Resource {
         if (!mode.hasRead())
             throw new SecurityException("No read permission");
 
+        if (!file.exists())
+            throw new FileNotFoundException("File does not exist");
+
         if (file.isDirectory())
             return FileUtils.getDirectorySize(file);
-            
+
         return file.length();
     }
 }

--- a/server/main/src/com/smartnote/server/resource/ReadOnlyResource.java
+++ b/server/main/src/com/smartnote/server/resource/ReadOnlyResource.java
@@ -3,6 +3,7 @@ package com.smartnote.server.resource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Objects;
 
 /**
  * <p>Wraps a resource and makes it read-only.</p>
@@ -13,8 +14,7 @@ import java.io.OutputStream;
  * @author Ethan Vrhel
  * @see com.smartnote.server.resource.Resource
  */
-public class ReadOnlyResource implements Resource {
-    
+public class ReadOnlyResource implements Resource {   
     private Resource resource;
 
     /**
@@ -23,7 +23,7 @@ public class ReadOnlyResource implements Resource {
      * @param resource The resource to wrap.
      */
     public ReadOnlyResource(Resource resource) {
-        this.resource = resource;
+        this.resource = Objects.requireNonNull(resource, "resource must not be null");
     }
 
     @Override

--- a/server/main/src/com/smartnote/server/resource/ReadOnlyResource.java
+++ b/server/main/src/com/smartnote/server/resource/ReadOnlyResource.java
@@ -40,4 +40,9 @@ public class ReadOnlyResource implements Resource {
     public void delete() throws SecurityException, IOException {
         throw new SecurityException("No delete permission");
     }
+
+    @Override
+    public long size() throws SecurityException, IOException {
+        return resource.size();
+    }
 }

--- a/server/main/src/com/smartnote/server/resource/Resource.java
+++ b/server/main/src/com/smartnote/server/resource/Resource.java
@@ -40,4 +40,14 @@ public interface Resource {
      * @throws IOException If the resource could not be deleted.
      */
     public void delete() throws SecurityException, IOException;
+
+    /**
+     * Gets the size of the resource.
+     * 
+     * @return The size.
+     * @throws SecurityException When the current identity does not
+     * have read permission to the resource.
+     * @throws IOException If the size could not be retrieved.
+     */
+    public long size() throws SecurityException, IOException;
 }

--- a/server/main/src/com/smartnote/server/resource/ResourceConfig.java
+++ b/server/main/src/com/smartnote/server/resource/ResourceConfig.java
@@ -27,9 +27,22 @@ public class ResourceConfig implements CommandLineHandler, Validator {
      */
     public static final String DEFAULT_SESSION_DIR = "sessions";
 
+    /**
+     * Default maximum upload size.
+     */
+    public static final long DEFAULT_MAX_UPLOAD_SIZE = 1024 * 1024 * 100; // 100 MiB
+
+    /**
+     * Default session quota.
+     */
+    public static final long DEFAULT_SESSION_QUOTA = 1024 * 1024 * 1024; // 1 GiB
+
     private String privateDir;
     private String publicDir;
     private String sessionDir;
+
+    private long maxUploadSize;
+    private long sessionQuota;
     
     /**
      * Creates a new ResourceConfig object with default values.
@@ -38,6 +51,8 @@ public class ResourceConfig implements CommandLineHandler, Validator {
         this.privateDir = DEFAULT_PRIVATE_DIR;
         this.publicDir = DEFAULT_PUBLIC_DIR;
         this.sessionDir = DEFAULT_SESSION_DIR;
+        this.maxUploadSize = DEFAULT_MAX_UPLOAD_SIZE;
+        this.sessionQuota = DEFAULT_SESSION_QUOTA;
     }
 
     /**
@@ -65,6 +80,24 @@ public class ResourceConfig implements CommandLineHandler, Validator {
      */
     public String getSessionDir() {
         return sessionDir;
+    }
+
+    /**
+     * Gets the maximum upload size.
+     * 
+     * @return The maximum upload size
+     */
+    public long getMaxUploadSize() {
+        return maxUploadSize;
+    }
+
+    /**
+     * Gets the session quota.
+     * 
+     * @return The session quota
+     */
+    public long getSessionQuota() {
+        return sessionQuota;
     }
 
     @Override

--- a/server/main/src/com/smartnote/server/resource/ResourceSystem.java
+++ b/server/main/src/com/smartnote/server/resource/ResourceSystem.java
@@ -42,6 +42,24 @@ public class ResourceSystem {
     public static final String SESSION_AUTH = "session";
 
     /**
+     * The supported MIME types for uploads.
+     */
+    public static final String[] SUPPORTED_MIME_TYPES = {
+        "application/pdf",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    };
+
+    /**
+     * The supported authorities.
+     */
+    public static final String[] AUTHORITIES = {
+        PUBLIC_AUTH,
+        PRIVATE_AUTH,
+        SESSION_AUTH
+    };
+
+    /**
      * Creates a new public resource name.
      * 
      * @param path The path.

--- a/server/main/src/com/smartnote/server/resource/ResourceSystem.java
+++ b/server/main/src/com/smartnote/server/resource/ResourceSystem.java
@@ -45,18 +45,18 @@ public class ResourceSystem {
      * The supported MIME types for uploads.
      */
     public static final String[] SUPPORTED_MIME_TYPES = {
-        "application/pdf",
-        "application/vnd.ms-powerpoint",
-        "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+            "application/pdf",
+            "application/vnd.ms-powerpoint",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation"
     };
 
     /**
      * The supported authorities.
      */
     public static final String[] AUTHORITIES = {
-        PUBLIC_AUTH,
-        PRIVATE_AUTH,
-        SESSION_AUTH
+            PUBLIC_AUTH,
+            PRIVATE_AUTH,
+            SESSION_AUTH
     };
 
     /**
@@ -114,7 +114,7 @@ public class ResourceSystem {
         this.publicDir = FileUtils.getCanonicalFile(config.getPrivateDir()).toPath();
         this.privateDir = FileUtils.getCanonicalFile(config.getPublicDir()).toPath();
         this.sessionDir = FileUtils.getCanonicalFile(config.getSessionDir()).toPath();
-        
+
         this.fileResourceFactory = (file, mode) -> new FileResource(file.toFile(), mode);
     }
 
@@ -182,7 +182,7 @@ public class ResourceSystem {
 
         int colonIndex = name.indexOf(':');
         if (colonIndex == -1)
-            throw new NoSuchResourceException(name);
+            throw new InvalidPathException(name, "Path must be in the format authority:path");
 
         // parse authority and path
         String authority = name.substring(0, colonIndex);
@@ -202,19 +202,23 @@ public class ResourceSystem {
     }
 
     /**
-     * <p>Similar to <code>findResource</code>, but allows access to files that start with
-     * a period (meant to be hidden files).</p>
+     * <p>
+     * Similar to <code>findResource</code>, but allows access to files that start
+     * with
+     * a period (meant to be hidden files).
+     * </p>
      * 
-     * @param authority The authority. Cannot be <code>null</code>.
-     * @param path The path within the authority. Cannot be <code>null</code>.
+     * @param authority  The authority. Cannot be <code>null</code>.
+     * @param path       The path within the authority. Cannot be <code>null</code>.
      * @param permission The permission to use. Cannot be <code>null</code>.
      * @return The resource. Never <code>null</code>.
-     * @throws SecurityException If the permission is not sufficient to access the
-     *                           resource.
-     * @throws InvalidPathException If the path is invalid.
+     * @throws SecurityException       If the permission is not sufficient to access
+     *                                 the
+     *                                 resource.
+     * @throws InvalidPathException    If the path is invalid.
      * @throws NoSuchResourceException If the resource does not exist, or is not
      *                                 accessible.
-     * @throws IOException If an I/O error occurs.
+     * @throws IOException             If an I/O error occurs.
      */
     public Resource findActualResource(String authority, Path path, Permission permission)
             throws SecurityException, InvalidPathException, NoSuchResourceException, IOException {

--- a/server/main/test/com/smartnote/server/RemoveTest.java
+++ b/server/main/test/com/smartnote/server/RemoveTest.java
@@ -1,0 +1,108 @@
+package com.smartnote.server;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+import com.smartnote.server.api.v1.Remove;
+import com.smartnote.server.resource.ResourceConfig;
+import com.smartnote.testing.RouteTest;
+import com.smartnote.testing.VirtualFileSystem;
+
+public class RemoveTest extends RouteTest {
+    public static final String TEST_FILE = "test.txt";
+    public static final byte[] TEST_FILE_DATA = "Hello World!".getBytes();
+
+    private Remove remove;
+
+    private Path publicPath;
+    private Path privatePath;
+    private Path sessionPath;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        remove = new Remove();
+
+        ResourceConfig config = Server.getServer().getConfig().getResourceConfig();
+
+        String token = activateSession();
+
+        publicPath = Paths.get(config.getPublicDir(), TEST_FILE);
+        privatePath = Paths.get(config.getPrivateDir(), TEST_FILE);
+        sessionPath = getSession(token).getSessionDirectory().resolve(TEST_FILE);
+
+        // write a file to all authorities
+        writeTestFile(publicPath);
+        writeTestFile(privatePath);
+        writeTestFile(sessionPath);
+    }
+
+    @Test
+    public void testRemoveSession() throws Exception {
+        setRequestQueryParam("name", "session:" + TEST_FILE);
+        doApiTest(remove, 200);
+        assertFalse(getFileSystem().exists(sessionPath));
+    }
+
+    @Test
+    public void testRemoveSessionUnauthorized() throws Exception {
+        setRequestQueryParam("name", "session:" + TEST_FILE);
+        deactivateSession();
+        doApiTest(remove, 401);
+        assertTrue(getFileSystem().exists(sessionPath));
+    }
+
+    @Test
+    public void testRemovePublic() throws Exception {
+        setRequestQueryParam("name", "public:" + TEST_FILE);
+        doApiTest(remove, 403);
+        assertTrue(getFileSystem().exists(publicPath));
+    }
+
+    @Test
+    public void testRemovePublicUnauthorized() throws Exception {
+        testRemovePublic(); // should be the same
+    }
+
+    @Test
+    public void testRemovePrivate() throws Exception {
+        setRequestQueryParam("name", "private:" + TEST_FILE);
+        doApiTest(remove, 403);
+        assertTrue(getFileSystem().exists(privatePath));
+    }
+
+    @Test
+    public void testRemovePrivateUnauthorized() throws Exception {
+        testRemovePrivate(); // should be the same
+    }
+
+    @Test
+    public void testRemoveDoesntExist() throws Exception {
+        setRequestQueryParam("name", "session:doesntexist");
+        doApiTest(remove, 404);
+    }
+
+    @Test
+    public void testRemoveInvalidName() throws Exception {
+        setRequestQueryParam("name", "invalidname");
+        doApiTest(remove, 400);
+    }
+
+    @Test
+    public void testRemoveNoName() throws Exception {
+        doApiTest(remove, 400);
+    }
+
+    private void writeTestFile(Path path) throws Exception {
+        VirtualFileSystem fileSystem = getFileSystem();
+        OutputStream out = fileSystem.openOutputStream(path);
+        out.write(TEST_FILE_DATA);
+        out.close();
+    }
+}

--- a/server/main/test/com/smartnote/server/RescInfoTest.java
+++ b/server/main/test/com/smartnote/server/RescInfoTest.java
@@ -1,0 +1,66 @@
+package com.smartnote.server;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.smartnote.server.api.v1.RescInfo;
+import com.smartnote.server.resource.ResourceConfig;
+import com.smartnote.testing.RouteTest;
+
+import spark.Response;
+
+/**
+ * <p>
+ * Tests the <code>rescinfo</code> RPC.
+ * </p>
+ * 
+ * @author Ethan Vrhel
+ * @see com.smartnote.server.api.v1.RescInfo
+ */
+public class RescInfoTest extends RouteTest {
+    private RescInfo rescInfo;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        rescInfo = new RescInfo();
+    }
+
+    @Test
+    public void testRescInfoBasic() throws Exception {
+        ResourceConfig config = Server.getServer().getConfig().getResourceConfig();
+        doApiTest(rescInfo, 200);
+
+        // check response json has all fields
+        JsonObject json = responseJson();
+        JsonElement element;
+
+        JsonPrimitive sessionQuota;
+        element = json.get("sessionQuota");
+        assertNotNull(element);
+        assertTrue(element.isJsonPrimitive());
+        sessionQuota = element.getAsJsonPrimitive();
+        assertTrue(sessionQuota.isNumber());
+        assertEquals(config.getSessionQuota(), sessionQuota.getAsLong());
+
+        JsonPrimitive maxUploadSize;
+        element = json.get("maxUploadSize");
+        assertNotNull(element);
+        assertTrue(element.isJsonPrimitive());
+        maxUploadSize = element.getAsJsonPrimitive();
+        assertTrue(maxUploadSize.isNumber());
+        assertEquals(config.getMaxUploadSize(), maxUploadSize.getAsLong());
+
+        element = json.get("supportedTypes");
+        assertNotNull(element);
+        assertTrue(element.isJsonArray());
+
+        element = json.get("authorities");
+        assertNotNull(element);
+        assertTrue(element.isJsonArray());
+    }
+}

--- a/server/main/test/com/smartnote/testing/BaseServerTest.java
+++ b/server/main/test/com/smartnote/testing/BaseServerTest.java
@@ -6,6 +6,7 @@ import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 
+import com.smartnote.server.Config;
 import com.smartnote.server.Server;
 import com.smartnote.server.auth.Session;
 import com.smartnote.server.auth.SessionManager;
@@ -19,10 +20,12 @@ import spark.Request;
 import spark.Response;
 
 /**
- * <p>Base class for tests that require a running the server (i.e. ones
+ * <p>
+ * Base class for tests that require a running the server (i.e. ones
  * that directly or indirectly use the <code>Server</code> class).
  * Provides a <code>Session</code> instance that can be used to
- * test components that require a session.</p>
+ * test components that require a session.
+ * </p>
  * 
  * @author Ethan Vrhel
  * @see com.smartnote.server.Server
@@ -51,11 +54,15 @@ public class BaseServerTest extends BaseTest {
             return null;
         return createSessionObject();
     }
-    
+
     // sets up the server for testing
     private void setupServer() throws Exception {
         Server server = Server.getServer();
         Class<Server> serverClass = Server.class;
+
+        Field configField = serverClass.getDeclaredField("config");
+        configField.setAccessible(true);
+        configField.set(server, createConfig());
 
         // set the resource system
         Field resourceSystemField = serverClass.getDeclaredField("resourceSystem");
@@ -66,6 +73,10 @@ public class BaseServerTest extends BaseTest {
         Field sessionManagerField = serverClass.getDeclaredField("sessionManager");
         sessionManagerField.setAccessible(true);
         sessionManagerField.set(server, createSessionManager());
+    }
+
+    private Config createConfig() {
+        return new Config();
     }
 
     // creates the resource system for testing
@@ -93,14 +104,15 @@ public class BaseServerTest extends BaseTest {
 
         when(sessionManager.createSession()).thenAnswer(invokation -> createNewSession());
 
-        when(sessionManager.isTokenValid(anyString())).thenAnswer(invokation -> invokation.getArguments()[0].equals(SESSION_TOKEN));
-        
+        when(sessionManager.isTokenValid(anyString()))
+                .thenAnswer(invokation -> invokation.getArguments()[0].equals(SESSION_TOKEN));
+
         return sessionManager;
     }
 
     private Session createNewSession() throws Exception {
         Session session = createSessionObject();
-        
+
         // create the token file
         Path tokenFile = session.getSessionDirectory().resolve(".token");
         OutputStream tokenOut = getFileSystem().openOutputStream(tokenFile);
@@ -115,7 +127,7 @@ public class BaseServerTest extends BaseTest {
         SessionPermission permission = mock(SessionPermission.class);
 
         Path sessionDirectory = Server.getServer().getResourceSystem().getSessionDir().resolve(SESSION_TOKEN);
-        
+
         when(session.getId()).thenReturn(SESSION_TOKEN);
         when(session.getSessionDirectory()).thenReturn(sessionDirectory);
 
@@ -135,7 +147,7 @@ public class BaseServerTest extends BaseTest {
 
         when(session.getPermission()).thenReturn(permission);
         when(permission.getSession()).thenReturn(session);
-    
+
         return session;
     }
 }

--- a/server/main/test/com/smartnote/testing/RouteTest.java
+++ b/server/main/test/com/smartnote/testing/RouteTest.java
@@ -15,12 +15,16 @@ import spark.Response;
 import spark.Route;
 
 /**
- * <p>Used for testing Spark routes. This class creates mock <code>Request</code>
+ * <p>
+ * Used for testing Spark routes. This class creates mock <code>Request</code>
  * and <code>Response</code> instances and provides methods for setting the
- * request parameters and handling the route.</p>
+ * request parameters and handling the route.
+ * </p>
  * 
- * <p>Not all methods are implemented. If you need to use a method that is not
- * implemented, add it to the class and submit a pull request.</p>
+ * <p>
+ * Not all methods are implemented. If you need to use a method that is not
+ * implemented, add it to the class and submit a pull request.
+ * </p>
  * 
  * @author Ethan Vrhel
  * @see spark.Route
@@ -28,7 +32,7 @@ import spark.Route;
  * @see spark.Response
  */
 public class RouteTest extends BaseServerTest {
-    
+
     // request
     private Request request;
     private Map<String, String> requestQueryParams;
@@ -55,7 +59,7 @@ public class RouteTest extends BaseServerTest {
     public void tearDown() throws Exception {
         super.tearDown();
     }
-  
+
     /**
      * Handle a route.
      * 
@@ -68,7 +72,7 @@ public class RouteTest extends BaseServerTest {
         Object r = route.handle(request, response);
         if (r != null)
             response.body(r.toString());
-        
+
         if (response.status() == 0)
             response.status(200); // default status
 
@@ -80,7 +84,7 @@ public class RouteTest extends BaseServerTest {
      * code, the response type, and the response body.
      * 
      * @param route the route to test.
-     * @param code the expected response code.
+     * @param code  the expected response code.
      * 
      * @return the response.
      */
@@ -89,6 +93,8 @@ public class RouteTest extends BaseServerTest {
         int status = response.status();
 
         assertEquals(code, status);
+
+        assertNotNull(response.body());
 
         assertEquals("application/json", response.type());
         assertTrue(responseJson().has("message"));
@@ -112,7 +118,7 @@ public class RouteTest extends BaseServerTest {
     /**
      * Sets a query parameter for the request.
      * 
-     * @param key the key.
+     * @param key   the key.
      * @param value the value.
      */
     public void setRequestQueryParam(String key, String value) {
@@ -146,14 +152,15 @@ public class RouteTest extends BaseServerTest {
         this.requestContentType = requestContentType;
     }
 
-    public void activateSession() {
+    public String activateSession() {
         requestHeaders.put("Authorization", SESSION_TOKEN);
+        return SESSION_TOKEN;
     }
 
     public void deactivateSession() {
         requestHeaders.remove("Authorization");
     }
-    
+
     // creates a mock request
     private Request mockRequest() {
         Request request = mock(Request.class);
@@ -176,7 +183,7 @@ public class RouteTest extends BaseServerTest {
 
         // Request.contentType()
         when(request.contentType()).thenAnswer(invokation -> requestContentType);
-        
+
         this.requestQueryParams = new HashMap<>();
         this.requestHeaders = new HashMap<>();
         return request;

--- a/server/main/test/com/smartnote/testing/VirtualFileSystem.java
+++ b/server/main/test/com/smartnote/testing/VirtualFileSystem.java
@@ -15,11 +15,13 @@ import com.smartnote.server.resource.FileResourceFactory;
 import com.smartnote.server.resource.Resource;
 
 /**
- * <p>Pseudo file system for testing.</p>
+ * <p>
+ * Pseudo file system for testing.
+ * </p>
  * 
  * @author Ethan Vrhel
  */
-public class VirtualFileSystem  {
+public class VirtualFileSystem {
     private Map<Path, VirtualFile> files;
 
     /**
@@ -91,7 +93,7 @@ public class VirtualFileSystem  {
     public boolean exists(Path path) {
         return files.containsKey(path);
     }
-    
+
     /**
      * Represents a resource in the virtual file system.
      */
@@ -102,7 +104,7 @@ public class VirtualFileSystem  {
         VirtualFileResource(Path path, AccessMode mode) {
             this.path = path;
             this.mode = mode;
-        }           
+        }
 
         @Override
         public InputStream openInputStream() throws SecurityException, IOException {
@@ -124,7 +126,15 @@ public class VirtualFileSystem  {
                 throw new SecurityException("No delete permission");
             VirtualFileSystem.this.delete(path);
         }
-        
+
+        @Override
+        public long size() throws SecurityException, IOException {
+            VirtualFile file = files.get(path);
+            if (file == null)
+                throw new FileNotFoundException(path.toString());
+            return file.data.length;
+        }
+
     }
 
     /**
@@ -133,7 +143,7 @@ public class VirtualFileSystem  {
     private static class VirtualFile {
         byte[] data;
         boolean isDirectory;
-        
+
         int readers; // multiple readers at a time
         boolean isOpenedForWriting; // only one writer at a time
 
@@ -145,7 +155,7 @@ public class VirtualFileSystem  {
 
             this.readers = 0;
             this.isOpenedForWriting = false;
-            
+
             this.lock = new Object();
         }
 
@@ -197,7 +207,7 @@ public class VirtualFileSystem  {
             public void write(byte[] b, int off, int len) throws IOException {
                 out.write(b, off, len);
             }
-            
+
             @Override
             public void close() throws IOException {
                 synchronized (lock) {

--- a/server/scripts/remove.py
+++ b/server/scripts/remove.py
@@ -34,14 +34,13 @@ def upload_file(
     if auth:
         headers['Authorization'] = auth
 
-    r = requests.get(url, headers=headers)
+    r = requests.post(url, headers=headers)
     auth = r.headers.get('Authorization', None)
 
     if r.status_code == 200:
         print(f'Removed')
     else:
         print(f'Failed: {r.status_code} {r.reason}')
-        print(r.text)
 
     return auth
 

--- a/server/scripts/remove.py
+++ b/server/scripts/remove.py
@@ -6,14 +6,13 @@ import requests
 import sys
 import urllib.parse
 import cmdline as cl
-import json
 
 def upload_file(
         base_url: str,
-        filename: str,
+        resc: str,
         auth: Union[str, None]=None) -> Union[str, None]:
     """
-    Upload a file to the server. See README.md for more information.
+    Remove a file from the server. See README.md for more information.
 
     Parameters:
     - `base_url`: Server base URL.
@@ -25,27 +24,21 @@ def upload_file(
     The new authentication token, if any.
     """
     
-    print(f'Upload {filename}... ', end='')
+    print(f'Remove {resc}... ', end='')
 
-    with open(filename, 'rb') as f:
-        data = f.read()
-        f.close()
-
-    filename_safe = urllib.parse.quote(filename)
-    url = f'{base_url}/api/v1/upload?name={filename_safe}'
+    resc_safe = urllib.parse.quote(resc)
+    url = f'{base_url}/api/v1/remove?name={resc_safe}'
 
     headers = {}
 
     if auth:
         headers['Authorization'] = auth
 
-    r = requests.post(url, data=data, headers=headers)
+    r = requests.get(url, headers=headers)
     auth = r.headers.get('Authorization', None)
 
     if r.status_code == 200:
-        print(r.text)
-        response = json.loads(r.text)
-        print(f'Done ({len(data)} bytes transfered to {response["name"]})')
+        print(f'Removed')
     else:
         print(f'Failed: {r.status_code} {r.reason}')
         print(r.text)
@@ -53,8 +46,8 @@ def upload_file(
     return auth
 
 def usage():
-    print('Usage: ./upload.py [options...] <host> [files...]')
-    print('Upload one or more files to the server using the upload RPC.')
+    print('Usage: ./remove.py [options...] <host> [resource...]')
+    print('Remove one or more files from the server using the remove RPC.')
     print('Options:')
     print('  -h  --help           Show this help message and exit')
     print('  -a, --auth <token>   Authentication token')
@@ -77,7 +70,7 @@ def main() -> int:
         return usage()
 
     host = args[0]
-    files = args[1:]
+    resources = args[1:]
     
     if host is None:
         print('Missing host')
@@ -86,8 +79,8 @@ def main() -> int:
 
     auth = options.get('auth', None)
 
-    if len(files) == 0:
-        print('No files')
+    if len(resources) == 0:
+        print('No resources')
         return 1
     
     # parse port
@@ -121,10 +114,10 @@ def main() -> int:
 
     # upload files
     try:
-        for filename in files:
-            auth = upload_file(url, filename, auth=auth)
+        for resc in resources:
+            auth = upload_file(url, resc, auth=auth)
     except Exception as e:
-        print(f'{e.__class__.__name__} uploading to {url}')
+        print(f'{e.__class__.__name__} removing from {url}')
         return 1
     
     print(f'Auth token: {auth}')


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Added the `remove` RPC, which is used to delete resources on the server.

Added the `rescinfo` RPC, which gets info about the resource system on the server (such as max file size).

Also adjusted the server documentation. Moved information about resources into `RESOURCES.md` and `INTERFACES.md` now references the document.

## QA Instructions, Screenshots, Recordings

All RPCs take fully qualified resource names (except `upload`, which takes only a name).

Paths are in the form:

```<authority>:<path>```

`authority` can be `public`, `private`, or `session`, which correspond to public resources, server resources, and per-session resources, respectively.

`path` is a path to a resource within the authority.

The client making requests has different permissions depending on the authorization status and the authority being accessed.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: I will add later
- [ ] I need help with writing tests