### PR TITLE
Implemented ExportSuccess page

### DIFF
--- a/client/src/components/ExportSuccess.tsx
+++ b/client/src/components/ExportSuccess.tsx
@@ -1,27 +1,30 @@
 import { IoMdArrowBack as Arrow } from "react-icons/io";
-import { useNavigate, Link } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { twMerge } from 'tailwind-merge';
 
 import H2 from "./H2";
 import Body from "./Body";
 import Button from "./Button";
 
+interface ExportSuccessType extends React.HTMLAttributes<HTMLDivElement> {
+  prev: () => void;
+}
+
 const ExportSuccess = ({
+  prev,
   className,
   ...rest
-}: React.HTMLAttributes<HTMLDivElement>) => {
-  const navigate = useNavigate();
-
+}: ExportSuccessType) => {
   return (
     <div
-      className={twMerge('flex flex-col items-center gap-5 mx-36', className)}
+      className={twMerge('flex flex-col items-center gap-5', className)}
       {...rest}
     >
       <Button
         icon={Arrow}
         variant='tertiary'
-        className='absolute left-0'
-        onClick={() => navigate(-1)}
+        className='absolute left-16'
+        onClick={() => prev()}
       >
         Back
       </Button>
@@ -33,7 +36,7 @@ const ExportSuccess = ({
         <Link to='/' tabIndex={-1}>
           <Button variant='secondary'>Home</Button>
         </Link>
-        <a href='https://www.notion.so/' target='_blank'>
+        <a href='https://www.notion.so/' target='_blank' tabIndex={-1}>
           <Button>Go to Notion</Button>
         </a>
       </div>

--- a/client/src/components/ExportSuccess.tsx
+++ b/client/src/components/ExportSuccess.tsx
@@ -1,17 +1,18 @@
-import { IoMdArrowBack as Arrow } from "react-icons/io";
-import { Link } from "react-router-dom";
+import { IoMdArrowBack as Arrow } from 'react-icons/io';
 import { twMerge } from 'tailwind-merge';
 
-import H2 from "./H2";
-import Body from "./Body";
-import Button from "./Button";
+import H2 from './H2';
+import Body from './Body';
+import Button from './Button';
 
 interface ExportSuccessType extends React.HTMLAttributes<HTMLDivElement> {
   prev: () => void;
+  goHome: () => void;
 }
 
 const ExportSuccess = ({
   prev,
+  goHome,
   className,
   ...rest
 }: ExportSuccessType) => {
@@ -29,13 +30,11 @@ const ExportSuccess = ({
         Back
       </Button>
       <H2>Export Successful!</H2>
-      <Body>
-        Congrats! Check out your new notes page :&#41;
-      </Body>
+      <Body>Congrats! Check out your new notes page :&#41;</Body>
       <div className='flex gap-5'>
-        <Link to='/' tabIndex={-1}>
-          <Button variant='secondary'>Home</Button>
-        </Link>
+        <Button onClick={goHome} variant='secondary'>
+          Home
+        </Button>
         <a href='https://www.notion.so/' target='_blank' tabIndex={-1}>
           <Button>Go to Notion</Button>
         </a>

--- a/client/src/components/ExportSuccess.tsx
+++ b/client/src/components/ExportSuccess.tsx
@@ -1,0 +1,44 @@
+import { IoMdArrowBack as Arrow } from "react-icons/io";
+import { useNavigate, Link } from "react-router-dom";
+import { twMerge } from 'tailwind-merge';
+
+import H2 from "./H2";
+import Body from "./Body";
+import Button from "./Button";
+
+const ExportSuccess = ({
+  className,
+  ...rest
+}: React.HTMLAttributes<HTMLDivElement>) => {
+  const navigate = useNavigate();
+
+  return (
+    <div
+      className={twMerge('flex flex-col items-center gap-5 mx-36', className)}
+      {...rest}
+    >
+      <Button
+        icon={Arrow}
+        variant='tertiary'
+        className='absolute left-0'
+        onClick={() => navigate(-1)}
+      >
+        Back
+      </Button>
+      <H2>Export Successful!</H2>
+      <Body>
+        Congrats! Check out your new notes page :&#41;
+      </Body>
+      <div className='flex gap-5'>
+        <Link to='/' tabIndex={-1}>
+          <Button variant='secondary'>Home</Button>
+        </Link>
+        <a href='https://www.notion.so/' target='_blank'>
+          <Button>Go to Notion</Button>
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default ExportSuccess;

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import FileUpload from '../components/FileUpload';
 import Customization from '../components/Customization';
+// import ExportSuccess from '../components/ExportSuccess';
 
 const Home = () => {
   const [index, setIndex] = useState<number>(() => {
@@ -24,16 +25,21 @@ const Home = () => {
     });
   };
 
+  const goHome = () => {
+    setIndex(0);
+    localStorage.setItem('index', '0');
+  };
+
   const renderPage = () => {
     switch (index) {
       case 0:
         return <FileUpload next={next} />;
       case 1:
         return <Customization files={[]} prev={prev} next={next} />;
+      // case _:
+      //   return <ExportSuccess prev={prev} goHome={goHome} />;
       default:
-        // in case something goes wrong, just go back to the initial page
-        setIndex(0);
-        localStorage.setItem('index', '0');
+        goHome();
         return null;
     }
   };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
A page that is displayed after a successful export to Notion, where the user can go back `Home` or to `Notion` to check out their notes.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

https://github.com/davidpak/SmartNote/assets/137979931/de5c3826-e2c8-4bd6-9203-11ef16fc8686

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [x] Semantic HTML implemented?
- [x] Keyboard operability supported?
- [x] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [x] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: I don't think we need to test this page
- [ ] I need help with writing tests
