### PR TITLE
Added tests for markdown/notion and some refactors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ __pycache__
 server/config.json
 server/private
 server/test-results
-server/.session
+.session
 
 #####################################################################
 # General

--- a/server/main/src/com/smartnote/server/export/JSONExporter.java
+++ b/server/main/src/com/smartnote/server/export/JSONExporter.java
@@ -6,7 +6,9 @@ import com.google.gson.JsonObject;
 import com.smartnote.server.format.MarkdownConverter;
 
 /**
- * <p>Exports to JSON.</p>
+ * <p>
+ * Exports to JSON.
+ * </p>
  * 
  * @author Ethan Vrhel
  * @see ResourceExporter
@@ -15,7 +17,7 @@ import com.smartnote.server.format.MarkdownConverter;
 public class JSONExporter implements ResourceExporter {
     @Override
     public MarkdownConverter<JsonObject> createConverter(ExportOptions options, Permission permission) {
-        return (md) -> md.getParsedJson();
+        return (md) -> md.writeJSON();
     }
 
     @Override

--- a/server/main/src/com/smartnote/server/format/JSONVisitor.java
+++ b/server/main/src/com/smartnote/server/format/JSONVisitor.java
@@ -105,7 +105,7 @@ class JSONVisitor extends AbstractVisitor {
 
     @Override
     public void visit(Link link) {
-        applyStyle(link, styleStack.peek().setHref(link.getDestination()));
+        applyStyle(link, styleStack.peek().setLink(link.getDestination()));
     }
 
     @Override
@@ -145,7 +145,7 @@ class JSONVisitor extends AbstractVisitor {
 
     @Override
     public void visit(LinkReferenceDefinition linkReferenceDefinition) {
-        applyStyle(linkReferenceDefinition, styleStack.peek().setHref(linkReferenceDefinition.getDestination()));
+        applyStyle(linkReferenceDefinition, styleStack.peek().setLink(linkReferenceDefinition.getDestination()));
     }
 
     @Override
@@ -198,7 +198,7 @@ class JSONVisitor extends AbstractVisitor {
                 json.add("style", styleObject);
         }
     }
-    
+
     private void emitCode(String type, String literal, String language, boolean omitStyle) {
         styleStack.push(styleStack.peek().setCode());
         emitLiteral(type, literal, omitStyle);
@@ -212,22 +212,22 @@ class JSONVisitor extends AbstractVisitor {
         boolean italic;
         boolean code;
 
-        String href;
+        String link;
 
         public Style() {
             bold = false;
             italic = false;
             code = false;
-            href = null;
+            link = null;
         }
 
         public Style(Style style) {
             bold = style.bold;
             italic = style.italic;
             code = style.code;
-            href = style.href;
+            link = style.link;
         }
-        
+
         public JsonObject createJson() {
             JsonObject json = new JsonObject();
             if (bold)
@@ -239,8 +239,8 @@ class JSONVisitor extends AbstractVisitor {
             if (code)
                 json.addProperty("code", true);
 
-            if (href != null)
-                json.addProperty("href", href);
+            if (link != null)
+                json.addProperty("link", link);
 
             return json;
         }
@@ -263,9 +263,9 @@ class JSONVisitor extends AbstractVisitor {
             return style;
         }
 
-        public Style setHref(String href) {
+        public Style setLink(String link) {
             Style style = new Style(this);
-            style.href = href;
+            style.link = link;
             return style;
         }
     }

--- a/server/main/src/com/smartnote/server/format/MarkdownConverter.java
+++ b/server/main/src/com/smartnote/server/format/MarkdownConverter.java
@@ -1,6 +1,21 @@
 package com.smartnote.server.format;
 
+/**
+ * <p>
+ * Base interface for converting markdown to a specific format.
+ * </p>
+ * 
+ * @param <T> The type to convert to.
+ * @see ParsedMarkdown
+ */
 @FunctionalInterface
 public interface MarkdownConverter<T> {
+
+    /**
+     * Converts the parsed markdown to the specified format.
+     * 
+     * @param markdown The parsed markdown.
+     * @return The converted markdown.
+     */
     T convert(ParsedMarkdown markdown);
 }

--- a/server/main/src/com/smartnote/server/format/MarkdownVisitor.java
+++ b/server/main/src/com/smartnote/server/format/MarkdownVisitor.java
@@ -1,57 +1,88 @@
 package com.smartnote.server.format;
 
+import com.smartnote.server.format.nodes.BlockQuote;
+import com.smartnote.server.format.nodes.BulletList;
+import com.smartnote.server.format.nodes.Document;
+import com.smartnote.server.format.nodes.FencedCodeBlock;
+import com.smartnote.server.format.nodes.HardLineBreak;
+import com.smartnote.server.format.nodes.Heading;
+import com.smartnote.server.format.nodes.IndentedCodeBlock;
+import com.smartnote.server.format.nodes.ListItem;
+import com.smartnote.server.format.nodes.MarkdownNode;
+import com.smartnote.server.format.nodes.OrderedList;
+import com.smartnote.server.format.nodes.Paragraph;
+import com.smartnote.server.format.nodes.SoftLineBreak;
+import com.smartnote.server.format.nodes.Text;
+import com.smartnote.server.format.nodes.ThematicBreak;
+
+/**
+ * <p>
+ * Visits markdown nodes for processing.
+ * </p>
+ * 
+ * @author Ethan Vrhel
+ * @see MarkdownNode
+ */
 public abstract class MarkdownVisitor {
-    public void visitBlockQuote(ParsedMarkdown md) {
+    public void visit(BlockQuote md) {
         visitChildren(md);
     }
 
-    public void visitBulletList(ParsedMarkdown md) {
+    public void visit(BulletList md) {
         visitChildren(md);
     }
 
-    public void visitDocument(ParsedMarkdown md) {
+    public void visit(Document md) {
         visitChildren(md);
     }
 
-    public void visitFencedCodeBlock(ParsedMarkdown md) {
-    }
-
-    public void visitHardLineBreak(ParsedMarkdown md) {
+    public void visit(FencedCodeBlock md) {
         visitChildren(md);
     }
 
-    public void visitHeading(ParsedMarkdown md) {
+    public void visit(HardLineBreak md) {
         visitChildren(md);
     }
 
-    public void visitThematicBreak(ParsedMarkdown md) {
+    public void visit(Heading md) {
         visitChildren(md);
     }
 
-    public void visitIndentedCodeBlock(ParsedMarkdown md) {
-    }
-
-    public void visitListItem(ParsedMarkdown md) {
+    public void visit(IndentedCodeBlock md) {
         visitChildren(md);
     }
 
-    public void visitOrderedList(ParsedMarkdown md) {
+    public void visit(ListItem md) {
         visitChildren(md);
     }
 
-    public void visitParagraph(ParsedMarkdown md) {
+    public void visit(OrderedList md) {
         visitChildren(md);
     }
 
-    public void visitSoftLineBreak(ParsedMarkdown md) {
+    public void visit(Paragraph md) {
         visitChildren(md);
     }
 
-    public void visitText(ParsedMarkdown md) {
+    public void visit(SoftLineBreak md) {
+        visitChildren(md);
     }
 
-    public void visitChildren(ParsedMarkdown md) {
-        for (ParsedMarkdown child : md.getChildren())
+    public void visit(Text md) {
+        visitChildren(md);
+    }
+
+    public void visit(ThematicBreak md) {
+        visitChildren(md);
+    }
+
+    /**
+     * Accepts the children of the markdown node.
+     * 
+     * @param md The markdown node.
+     */
+    public void visitChildren(MarkdownNode md) {
+        for (MarkdownNode child : md.getChildren())
             child.accept(this);
     }
 }

--- a/server/main/src/com/smartnote/server/format/ParsedMarkdown.java
+++ b/server/main/src/com/smartnote/server/format/ParsedMarkdown.java
@@ -1,7 +1,8 @@
 package com.smartnote.server.format;
 
+import static com.smartnote.server.util.JSONUtil.*;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.commonmark.node.Node;
@@ -10,162 +11,222 @@ import org.commonmark.parser.Parser;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
+import com.smartnote.server.format.nodes.BlockQuote;
+import com.smartnote.server.format.nodes.BulletList;
+import com.smartnote.server.format.nodes.Document;
+import com.smartnote.server.format.nodes.FencedCodeBlock;
+import com.smartnote.server.format.nodes.HardLineBreak;
+import com.smartnote.server.format.nodes.Heading;
+import com.smartnote.server.format.nodes.IndentedCodeBlock;
+import com.smartnote.server.format.nodes.ListItem;
+import com.smartnote.server.format.nodes.MarkdownNode;
+import com.smartnote.server.format.nodes.OrderedList;
+import com.smartnote.server.format.nodes.Paragraph;
+import com.smartnote.server.format.nodes.SoftLineBreak;
+import com.smartnote.server.format.nodes.Text;
+import com.smartnote.server.format.nodes.ThematicBreak;
 import com.smartnote.server.util.JSONObjectSerializable;
 
+/**
+ * <p>
+ * Handles parsing of markdown to the internal representation.
+ * </p>
+ * 
+ * @author Ethan Vrhel
+ * @see MarkdownNode
+ */
 public class ParsedMarkdown implements JSONObjectSerializable {
-    public static ParsedMarkdown parse(String markdown) {
+
+    /**
+     * Parse markdown from a string.
+     * 
+     * @param markdown The markdown to parse.
+     * @return The parsed markdown.
+     * @throws IllegalArgumentException If the markdown is invalid.
+     */
+    public static ParsedMarkdown parse(String markdown) throws IllegalArgumentException {
         Node document = Parser.builder().build().parse(markdown);
 
         JsonObject parsed = new JsonObject();
         JSONVisitor visitor = new JSONVisitor(parsed);
         document.accept(visitor);
 
+        return parseFromJson(parsed);
+    }
+
+    /**
+     * Parse markdown from a JSON object, laid out in the internal representation.
+     * 
+     * @param json The JSON object to parse.
+     * @return The parsed markdown.
+     * @throws IllegalArgumentException If the JSON is invalid.
+     */
+    public static ParsedMarkdown parseFromJson(JsonObject json) throws IllegalArgumentException {
         ParsedMarkdown parsedMarkdown = new ParsedMarkdown();
-        parsedMarkdown.loadJSON(parsed);
+        parsedMarkdown.loadJSON(json);
         return parsedMarkdown;
     }
 
-    private JsonObject parsed;
-    private List<ParsedMarkdown> children;
+    private Document document;
+    private JsonObject json; // cached JSON
 
-    private String literal;
-    private Style style;
-    private String language;
-    private int level;
-
-    public ParsedMarkdown() {
-        this.parsed = new JsonObject();
-        this.children = new ArrayList<>();
-        this.literal = null;
-        this.style = new Style();
-        this.language = null;
-        this.level = 0;
+    private ParsedMarkdown() {
+        this.document = null;
     }
 
-    public String getType() {
-        return parsed.get("type").getAsString();
+    /**
+     * Get the document associated with this parsed markdown.
+     * 
+     * @return The document.
+     */
+    public Document getDocument() {
+        return document;
     }
 
-    public List<ParsedMarkdown> getChildren() {
-        return children;
-    }
-
-    public JsonObject getParsedJson() {
-        return parsed;
-    }
-
-    public String getLiteral() {
-        return literal;
-    }
-
-    public Style getStyle() {
-        return style;
-    }
-
-    public String getLanguage() {
-        return language;
-    }
-
-    public int getLevel() {
-        return level;
-    }
-
-    public void accept(MarkdownVisitor visitor) {
-        switch (getType()) {
-            case "blockQuote":
-                visitor.visitBlockQuote(this);
-                break;
-            case "bulletList":
-                visitor.visitBulletList(this);
-                break;
-            case "document":
-                visitor.visitDocument(this);
-                break;
-            case "fencedCodeBlock":
-                visitor.visitFencedCodeBlock(this);
-                break;
-            case "hardLineBreak":
-                visitor.visitHardLineBreak(this);
-                break;
-            case "heading":
-                visitor.visitHeading(this);
-                break;
-            case "thematicBreak":
-                visitor.visitThematicBreak(this);
-                break;
-            case "indentedCodeBlock":
-                visitor.visitIndentedCodeBlock(this);
-                break;
-            case "listItem":
-                visitor.visitListItem(this);
-                break;
-            case "orderedList":
-                visitor.visitOrderedList(this);
-                break;
-            case "paragraph":
-                visitor.visitParagraph(this);
-                break;
-            case "softLineBreak":
-                visitor.visitSoftLineBreak(this);
-                break;
-            case "text":
-                visitor.visitText(this);
-                break;
-            default:
-                throw new RuntimeException("Unknown type: " + getType());
-        }
-    }
-
+    /**
+     * Pretty print the JSON.
+     * 
+     * @return The pretty printed JSON.
+     */
     public String prettyPrint() {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        return gson.toJson(parsed);
+        return gson.toJson(document.writeJSON());
     }
 
     @Override
     public String toString() {
-        return new Gson().toJson(parsed);
-    }
-
-    @Override
-    public void loadJSON(JsonObject json) {
-        this.parsed = json;
-
-        JsonArray childrenJson = parsed.getAsJsonArray("children");
-        this.children = new ArrayList<>();
-        if (childrenJson != null) {
-            for (int i = 0; i < childrenJson.size(); i++) {
-                ParsedMarkdown md = new ParsedMarkdown();
-                md.loadJSON(childrenJson.get(i).getAsJsonObject());
-                this.children.add(md);
-            }
-        }
-        this.children = Collections.unmodifiableList(this.children);
-
-        JsonPrimitive literalPrimitive = parsed.getAsJsonPrimitive("literal");
-        if (literalPrimitive != null)
-            this.literal = literalPrimitive.getAsString();
-
-        JsonObject styleObject = parsed.getAsJsonObject("style");
-        if (styleObject != null)
-            this.style = Style.fromJSON(styleObject);
-        else
-            this.style = new Style();
-
-        JsonPrimitive languagePrimitive = parsed.getAsJsonPrimitive("language");
-        if (languagePrimitive != null)
-            this.language = languagePrimitive.getAsString();
-
-        JsonPrimitive levelPrimitive = parsed.getAsJsonPrimitive("level");
-        if (levelPrimitive != null)
-            this.level = levelPrimitive.getAsInt();
+        return document == null ? "null" : document.toString();
     }
 
     @Override
     public JsonObject writeJSON(JsonObject json) {
-        for (var entry : parsed.entrySet())
+        for (var entry : this.json.entrySet())
             json.add(entry.getKey(), entry.getValue().deepCopy());
         return json;
+    }
+
+    @Override
+    public void loadJSON(JsonObject json) throws IllegalArgumentException {
+        MarkdownNode node = parseMarkdownNode(json);
+        if (node instanceof Document document) {
+            this.document = document;
+            this.json = document.writeJSON(); // create a deep copy
+            return;
+        }
+
+        throw new IllegalArgumentException("Root node is not a document");
+    }
+
+    private MarkdownNode parseMarkdownNode(JsonObject json) {
+        List<MarkdownNode> children = getChildrenList(json);
+        String type = getStringOrNull(json, "type");
+        if (type == null)
+            throw new IllegalArgumentException("No node type in JSON object");
+
+        String language = getStringOrNull(json, "language");
+        String literal = getStringOrNull(json, "literal");
+        Style style = jsonToStyle(getObjectOrNull(json, "style"));
+
+        switch (type) {
+            case "blockQuote":
+                return new BlockQuote(children);
+            case "bulletList":
+                return new BulletList(children);
+            case "document":
+                return new Document(children);
+            case "fencedCodeBlock":
+                return new FencedCodeBlock(language, literal, style);
+            case "hardLineBreak":
+                return new HardLineBreak();
+            case "heading":
+                return new Heading(getIntOrException(json, "level"), children);
+            case "indentedCodeBlock":
+                return new IndentedCodeBlock(literal);
+            case "listItem":
+                return new ListItem(children);
+            case "orderedList":
+                return new OrderedList(getIntOrDefault(json, "startNumber", 1), children);
+            case "paragraph":
+                return new Paragraph(children);
+            case "softLineBreak":
+                return new SoftLineBreak();
+            case "text":
+                return new Text(literal, style);
+            case "thematicBreak":
+                return new ThematicBreak();
+            default:
+                throw new IllegalArgumentException("Unknown node type: " + type);
+        }
+    }
+
+    private List<MarkdownNode> getChildrenList(JsonObject json) {
+        JsonArray childrenArray = getArrayOrNull(json, "children");
+        if (childrenArray == null)
+            return null;
+
+        List<MarkdownNode> children = new ArrayList<>();
+        for (JsonElement e : childrenArray) {
+            if (e.isJsonObject()) {
+                JsonObject child = e.getAsJsonObject();
+                MarkdownNode node = parseMarkdownNode(child);
+                children.add(node);
+            }
+        }
+
+        return children;
+    }
+
+    /**
+     * Convert a style to JSON for use in the internal representation.
+     * 
+     * @param style The style to convert.
+     * @return The JSON representation of the style.
+     */
+    public static JsonObject styleToJson(Style style) {
+        JsonObject json = new JsonObject();
+
+        if (style == null)
+            return json;
+
+        if (style.bold())
+            json.addProperty("bold", style.bold());
+
+        if (style.italic())
+            json.addProperty("italic", style.italic());
+
+        if (style.code())
+            json.addProperty("code", style.code());
+
+        if (style.strikethrough())
+            json.addProperty("strikethrough", style.strikethrough());
+
+        if (style.underline())
+            json.addProperty("underline", style.underline());
+
+        if (style.link() != null)
+            json.addProperty("link", style.link());
+
+        return json;
+    }
+
+    /**
+     * Convert a JSON object to a style.
+     * 
+     * @param json The JSON object to convert.
+     * @return The style.
+     */
+    public static Style jsonToStyle(JsonObject json) {
+        if (json == null)
+            return new Style();
+
+        boolean bold = getBooleanOrFalse(json, "bold");
+        boolean italic = getBooleanOrFalse(json, "italic");
+        boolean code = getBooleanOrFalse(json, "code");
+        boolean strikethrough = getBooleanOrFalse(json, "strikethrough");
+        boolean underline = getBooleanOrFalse(json, "underline");
+        String link = getStringOrNull(json, "link");
+        return new Style(bold, italic, strikethrough, underline, code, link);
     }
 }

--- a/server/main/src/com/smartnote/server/format/Style.java
+++ b/server/main/src/com/smartnote/server/format/Style.java
@@ -1,17 +1,16 @@
 package com.smartnote.server.format;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
-import com.smartnote.server.util.JSONObjectSerializable;
+import com.smartnote.server.format.notion.NotionBlock;
 
 /**
- * Describe a style in Notion's internal format.
+ * <p>
+ * Describes a rich text style.
+ * </p>
  * 
  * @author Ethan Vrhel
+ * @see NotionBlock
  */
-public record Style(boolean bold, boolean italic, boolean strikethrough, boolean underline, boolean code, String link)
-        implements JSONObjectSerializable {
+public record Style(boolean bold, boolean italic, boolean strikethrough, boolean underline, boolean code, String link) {
     /**
      * Create a default style.
      */
@@ -74,60 +73,37 @@ public record Style(boolean bold, boolean italic, boolean strikethrough, boolean
         return new Style(bold, italic, strikethrough, underline, code, link);
     }
 
-    public static Style fromJSON(JsonObject json) {
-        JsonElement e;
-        JsonPrimitive p;
+    @Override
+    public boolean equals(Object o) {
+        if (o == null)
+            return false;
 
-        boolean bold = false;
-        boolean italic = false;
-        boolean strikethrough = false;
-        boolean underline = false;
-        boolean code = false;
-        String link = null;
+        if (o instanceof Style s) {
+            boolean b = s.bold == bold && s.italic == italic && s.strikethrough == strikethrough
+                    && s.underline == underline
+                    && s.code == code;
 
-        if ((e = json.get("bold")) != null && e.isJsonPrimitive() && (p = e.getAsJsonPrimitive()).isBoolean())
-            bold = p.getAsBoolean();
+            if (!b)
+                return false;
 
-        if ((e = json.get("italic")) != null && e.isJsonPrimitive() && (p = e.getAsJsonPrimitive()).isBoolean())
-            italic = p.getAsBoolean();
+            if (s.link == null)
+                return link == null;
 
-        if ((e = json.get("strikethrough")) != null && e.isJsonPrimitive() && (p = e.getAsJsonPrimitive()).isBoolean())
-            strikethrough = p.getAsBoolean();
+            return s.link.equals(link);
+        }
 
-        if ((e = json.get("underline")) != null && e.isJsonPrimitive() && (p = e.getAsJsonPrimitive()).isBoolean())
-            underline = p.getAsBoolean();
-
-        if ((e = json.get("code")) != null && e.isJsonPrimitive() && (p = e.getAsJsonPrimitive()).isBoolean())
-            code = p.getAsBoolean();
-
-        if ((e = json.get("link")) != null && e.isJsonPrimitive() && (p = e.getAsJsonPrimitive()).isString())
-            link = p.getAsString();
-
-        return new Style(bold, italic, strikethrough, underline, code, link);
+        return false;
     }
 
     @Override
-    public JsonObject writeJSON(JsonObject json) {
-        if (bold)
-            json.addProperty("bold", true);
-
-        if (italic)
-            json.addProperty("italic", true);
-
-        if (strikethrough)
-            json.addProperty("strikethrough", true);
-
-        if (underline)
-            json.addProperty("underline", true);
-
-        if (code)
-            json.addProperty("code", true);
-
-        return json;
+    public int hashCode() {
+        return Boolean.hashCode(bold) + Boolean.hashCode(italic) + Boolean.hashCode(strikethrough)
+                + Boolean.hashCode(underline) + Boolean.hashCode(code) + link.hashCode();
     }
 
     @Override
-    public void loadJSON(JsonObject json) throws UnsupportedOperationException {
-        throw new UnsupportedOperationException("Cannot load a Style from JSON");
+    public String toString() {
+        return "Style [bold=" + bold + ", italic=" + italic + ", strikethrough=" + strikethrough + ", underline="
+                + underline + ", code=" + code + ", link=" + link + "]";
     }
 }

--- a/server/main/src/com/smartnote/server/format/nodes/BlockQuote.java
+++ b/server/main/src/com/smartnote/server/format/nodes/BlockQuote.java
@@ -1,0 +1,21 @@
+package com.smartnote.server.format.nodes;
+
+import java.util.List;
+
+import com.smartnote.server.format.MarkdownVisitor;
+
+public class BlockQuote extends MarkdownNode {
+    public BlockQuote(List<MarkdownNode> children) {
+        super(children);
+    }
+
+    @Override
+    public void accept(MarkdownVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public String getType() {
+        return "blockQuote";
+    }
+}

--- a/server/main/src/com/smartnote/server/format/nodes/BulletList.java
+++ b/server/main/src/com/smartnote/server/format/nodes/BulletList.java
@@ -1,0 +1,23 @@
+package com.smartnote.server.format.nodes;
+
+import java.util.List;
+
+import com.smartnote.server.format.MarkdownVisitor;
+
+public class BulletList extends MarkdownNode {
+
+    public BulletList(List<MarkdownNode> children) {
+        super(children);
+    }
+
+    @Override
+    public void accept(MarkdownVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public String getType() {
+        return "bulletList";
+    }
+
+}

--- a/server/main/src/com/smartnote/server/format/nodes/Document.java
+++ b/server/main/src/com/smartnote/server/format/nodes/Document.java
@@ -1,0 +1,22 @@
+package com.smartnote.server.format.nodes;
+
+import java.util.List;
+
+import com.smartnote.server.format.MarkdownVisitor;
+
+public class Document extends MarkdownNode {
+
+    public Document(List<MarkdownNode> children) {
+        super(children);
+    }
+
+    @Override
+    public String getType() {
+        return "document";
+    }
+
+    @Override
+    public void accept(MarkdownVisitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/server/main/src/com/smartnote/server/format/nodes/FencedCodeBlock.java
+++ b/server/main/src/com/smartnote/server/format/nodes/FencedCodeBlock.java
@@ -1,0 +1,56 @@
+package com.smartnote.server.format.nodes;
+
+import com.google.gson.JsonObject;
+import com.smartnote.server.format.MarkdownVisitor;
+import com.smartnote.server.format.ParsedMarkdown;
+import com.smartnote.server.format.Style;
+
+public class FencedCodeBlock extends MarkdownNode {
+    private String language;
+    private String literal;
+    private Style style;
+
+    public FencedCodeBlock(String language, String literal, Style style) {
+        this.language = language;
+        this.literal = literal;
+        this.style = style == null ? new Style() : style;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public String getLiteral() {
+        return literal;
+    }
+
+    public Style getStyle() {
+        return style;
+    }
+
+    @Override
+    public JsonObject writeJSON(JsonObject json) {
+        super.writeJSON(json);
+
+        json.addProperty("literal", literal);
+
+        if (language != null)
+            json.addProperty("language", language);
+
+        JsonObject styleJson = ParsedMarkdown.styleToJson(style);
+        if (styleJson.size() > 0)
+            json.add("style", styleJson);
+
+        return json;
+    }
+
+    @Override
+    public void accept(MarkdownVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public String getType() {
+        return "fencedCodeBlock";
+    }
+}

--- a/server/main/src/com/smartnote/server/format/nodes/HardLineBreak.java
+++ b/server/main/src/com/smartnote/server/format/nodes/HardLineBreak.java
@@ -1,0 +1,17 @@
+package com.smartnote.server.format.nodes;
+
+import com.smartnote.server.format.MarkdownVisitor;
+
+public class HardLineBreak extends MarkdownNode {
+
+    @Override
+    public void accept(MarkdownVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public String getType() {
+        return "hardLineBreak";
+    }
+
+}

--- a/server/main/src/com/smartnote/server/format/nodes/Heading.java
+++ b/server/main/src/com/smartnote/server/format/nodes/Heading.java
@@ -1,0 +1,36 @@
+package com.smartnote.server.format.nodes;
+
+import java.util.List;
+
+import com.google.gson.JsonObject;
+import com.smartnote.server.format.MarkdownVisitor;
+
+public class Heading extends MarkdownNode {
+    private int level;
+
+    public Heading(int level, List<MarkdownNode> children) {
+        super(children);
+        this.level = level;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    @Override
+    public JsonObject writeJSON(JsonObject json) {
+        super.writeJSON(json);
+        json.addProperty("level", level);
+        return json;
+    }
+
+    @Override
+    public void accept(MarkdownVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public String getType() {
+        return "heading";
+    }
+}

--- a/server/main/src/com/smartnote/server/format/nodes/IndentedCodeBlock.java
+++ b/server/main/src/com/smartnote/server/format/nodes/IndentedCodeBlock.java
@@ -1,0 +1,34 @@
+package com.smartnote.server.format.nodes;
+
+import com.google.gson.JsonObject;
+import com.smartnote.server.format.MarkdownVisitor;
+
+public class IndentedCodeBlock extends MarkdownNode {
+    private String literal;
+
+    public IndentedCodeBlock(String literal) {
+        this.literal = literal;
+    }
+
+    public String getLiteral() {
+        return literal;
+    }
+
+    @Override
+    public JsonObject writeJSON(JsonObject json) {
+        super.writeJSON(json);
+        json.addProperty("literal", literal);
+        return json;
+    }
+
+    @Override
+    public void accept(MarkdownVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public String getType() {
+        return "indentedCodeBlock";
+    }
+
+}

--- a/server/main/src/com/smartnote/server/format/nodes/ListItem.java
+++ b/server/main/src/com/smartnote/server/format/nodes/ListItem.java
@@ -1,0 +1,23 @@
+package com.smartnote.server.format.nodes;
+
+import java.util.List;
+
+import com.smartnote.server.format.MarkdownVisitor;
+
+public class ListItem extends MarkdownNode {
+
+    public ListItem(List<MarkdownNode> children) {
+        super(children);
+    }
+
+    @Override
+    public void accept(MarkdownVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public String getType() {
+        return "listItem";
+    }
+
+}

--- a/server/main/src/com/smartnote/server/format/nodes/MarkdownNode.java
+++ b/server/main/src/com/smartnote/server/format/nodes/MarkdownNode.java
@@ -1,0 +1,105 @@
+package com.smartnote.server.format.nodes;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.smartnote.server.format.MarkdownVisitor;
+import com.smartnote.server.format.ParsedMarkdown;
+import com.smartnote.server.util.JSONObjectSerializable;
+
+/**
+ * Represents a node in the Markdown AST. This exists over commonmark's
+ * implementation as it provides an easier way for serialization. Especially
+ * with respect to text styling. Nodes are immutable.
+ * 
+ * @author Ethan Vrhel
+ * @see ParsedMarkdown
+ */
+public abstract class MarkdownNode implements JSONObjectSerializable {
+    private MarkdownNode[] children;
+
+    /**
+     * Constructs a new MarkdownNode.
+     * 
+     * @param children The children of the node. Can be <code>null</code>.
+     */
+    public MarkdownNode(List<MarkdownNode> children) {
+        if (children != null) {
+            this.children = new MarkdownNode[children.size()];
+            for (int i = 0; i < children.size(); i++)
+                this.children[i] = children.get(i);
+        } else {
+            this.children = new MarkdownNode[0];
+        }
+    }
+
+    /**
+     * Constructs a new MarkdownNode with no children.
+     */
+    public MarkdownNode() {
+        this(null);
+    }
+
+    /**
+     * Gets the children of the node.
+     * 
+     * @return The children of the node.
+     */
+    public MarkdownNode[] getChildren() {
+        MarkdownNode[] copy = new MarkdownNode[children.length];
+        System.arraycopy(children, 0, copy, 0, children.length);
+        return copy;
+    }
+
+    /**
+     * Accepts a visitor, calling the appropriate visit method.
+     * 
+     * @param visitor The visitor to accept.
+     */
+    public abstract void accept(MarkdownVisitor visitor);
+
+    /**
+     * Gets the type of the node.
+     * 
+     * @return The type of the node.
+     */
+    public abstract String getType();
+
+    @Override
+    public String toString() {
+        return new Gson().toJson(writeJSON());
+    }
+
+    @Override
+    public JsonObject writeJSON(JsonObject json) {
+        json.addProperty("type", getType());
+
+        if (children.length > 0) {
+            JsonArray childrenArray = new JsonArray();
+            for (MarkdownNode md : children)
+                childrenArray.add(md.writeJSON());
+            json.add("children", childrenArray);
+        }
+
+        return json;
+    }
+
+    @Override
+    public void loadJSON(JsonObject json) {
+        throw new UnsupportedOperationException("Use ParsedMarkdown to load from JSON");
+    }
+
+    /**
+     * Visits the children of the node.
+     * 
+     * @param visitor The visitor to accept.
+     */
+    public void visitChildren(MarkdownVisitor visitor) {
+        for (MarkdownNode md : children)
+            md.accept(visitor);
+    }
+}

--- a/server/main/src/com/smartnote/server/format/nodes/OrderedList.java
+++ b/server/main/src/com/smartnote/server/format/nodes/OrderedList.java
@@ -1,0 +1,36 @@
+package com.smartnote.server.format.nodes;
+
+import java.util.List;
+
+import com.google.gson.JsonObject;
+import com.smartnote.server.format.MarkdownVisitor;
+
+public class OrderedList extends MarkdownNode {
+    private int startNumber;
+
+    public OrderedList(int startNumber, List<MarkdownNode> children) {
+        super(children);
+        this.startNumber = startNumber;
+    }
+
+    public int getStartNumber() {
+        return startNumber;
+    }
+
+    @Override
+    public JsonObject writeJSON(JsonObject json) {
+        super.writeJSON(json);
+        json.addProperty("startNumber", startNumber);
+        return json;
+    }
+
+    @Override
+    public void accept(MarkdownVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public String getType() {
+        return "orderedList";
+    }
+}

--- a/server/main/src/com/smartnote/server/format/nodes/Paragraph.java
+++ b/server/main/src/com/smartnote/server/format/nodes/Paragraph.java
@@ -1,0 +1,23 @@
+package com.smartnote.server.format.nodes;
+
+import java.util.List;
+
+import com.smartnote.server.format.MarkdownVisitor;
+
+public class Paragraph extends MarkdownNode {
+
+    public Paragraph(List<MarkdownNode> children) {
+        super(children);
+    }
+
+    @Override
+    public void accept(MarkdownVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public String getType() {
+        return "paragraph";
+    }
+
+}

--- a/server/main/src/com/smartnote/server/format/nodes/SoftLineBreak.java
+++ b/server/main/src/com/smartnote/server/format/nodes/SoftLineBreak.java
@@ -1,0 +1,17 @@
+package com.smartnote.server.format.nodes;
+
+import com.smartnote.server.format.MarkdownVisitor;
+
+public class SoftLineBreak extends MarkdownNode {
+
+    @Override
+    public void accept(MarkdownVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public String getType() {
+        return "softLineBreak";
+    }
+
+}

--- a/server/main/src/com/smartnote/server/format/nodes/Text.java
+++ b/server/main/src/com/smartnote/server/format/nodes/Text.java
@@ -1,0 +1,47 @@
+package com.smartnote.server.format.nodes;
+
+import com.google.gson.JsonObject;
+import com.smartnote.server.format.MarkdownVisitor;
+import com.smartnote.server.format.ParsedMarkdown;
+import com.smartnote.server.format.Style;
+
+public class Text extends MarkdownNode {
+    private String literal;
+    private Style style;
+
+    public Text(String literal, Style style) {
+        this.literal = literal;
+        this.style = style;
+    }
+
+    public String getLiteral() {
+        return literal;
+    }
+
+    public Style getStyle() {
+        return style;
+    }
+
+    @Override
+    public void accept(MarkdownVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public String getType() {
+        return "text";
+    }
+
+    @Override
+    public JsonObject writeJSON(JsonObject json) {
+        super.writeJSON(json);
+
+        json.addProperty("literal", literal);
+
+        JsonObject styleObject = ParsedMarkdown.styleToJson(style);
+        if (styleObject.size() > 0)
+            json.add("style", styleObject);
+
+        return json;
+    }
+}

--- a/server/main/src/com/smartnote/server/format/nodes/ThematicBreak.java
+++ b/server/main/src/com/smartnote/server/format/nodes/ThematicBreak.java
@@ -1,0 +1,17 @@
+package com.smartnote.server.format.nodes;
+
+import com.smartnote.server.format.MarkdownVisitor;
+
+public class ThematicBreak extends MarkdownNode {
+
+    @Override
+    public void accept(MarkdownVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public String getType() {
+        return "thematicBreak";
+    }
+
+}

--- a/server/main/src/com/smartnote/server/format/notion/NotionConverter.java
+++ b/server/main/src/com/smartnote/server/format/notion/NotionConverter.java
@@ -3,12 +3,20 @@ package com.smartnote.server.format.notion;
 import com.smartnote.server.format.MarkdownConverter;
 import com.smartnote.server.format.ParsedMarkdown;
 
+/**
+ * <p>
+ * Handles conversion of markdown to Notion's representation.
+ * </p>
+ * 
+ * @author Ethan Vrhel
+ * @see NotionBlock
+ */
 public class NotionConverter implements MarkdownConverter<NotionBlock> {
 
     @Override
     public NotionBlock convert(ParsedMarkdown markdown) {
         NotionVisitor visitor = new NotionVisitor();
-        markdown.accept(visitor);
+        markdown.getDocument().accept(visitor);
         return visitor.getBlock();
     }
 }

--- a/server/main/src/com/smartnote/server/format/notion/NotionVisitor.java
+++ b/server/main/src/com/smartnote/server/format/notion/NotionVisitor.java
@@ -3,7 +3,19 @@ package com.smartnote.server.format.notion;
 import java.util.Stack;
 
 import com.smartnote.server.format.MarkdownVisitor;
-import com.smartnote.server.format.ParsedMarkdown;
+import com.smartnote.server.format.nodes.BulletList;
+import com.smartnote.server.format.nodes.Document;
+import com.smartnote.server.format.nodes.FencedCodeBlock;
+import com.smartnote.server.format.nodes.HardLineBreak;
+import com.smartnote.server.format.nodes.Heading;
+import com.smartnote.server.format.nodes.IndentedCodeBlock;
+import com.smartnote.server.format.nodes.ListItem;
+import com.smartnote.server.format.nodes.MarkdownNode;
+import com.smartnote.server.format.nodes.OrderedList;
+import com.smartnote.server.format.nodes.Paragraph;
+import com.smartnote.server.format.nodes.SoftLineBreak;
+import com.smartnote.server.format.nodes.Text;
+import com.smartnote.server.format.nodes.ThematicBreak;
 
 /**
  * <p>
@@ -25,25 +37,30 @@ class NotionVisitor extends MarkdownVisitor {
         this.listStack = new Stack<>();
     }
 
+    /**
+     * Retrieve the generated block.
+     * 
+     * @return The generated block.
+     */
     public NotionBlock getBlock() {
         return block;
     }
 
     @Override
-    public void visitBulletList(ParsedMarkdown md) {
+    public void visit(BulletList md) {
         this.listStack.push("bulleted_list_item");
         visitChildren(md);
         this.listStack.pop();
     }
 
     @Override
-    public void visitDocument(ParsedMarkdown md) {
+    public void visit(Document md) {
         this.block = new NotionBlock(null);
         visitChildren(md);
     }
 
     @Override
-    public void visitFencedCodeBlock(ParsedMarkdown md) {
+    public void visit(FencedCodeBlock md) {
         String language = md.getLanguage();
         if (language == null || language.length() == 0)
             language = "plain text";
@@ -56,39 +73,39 @@ class NotionVisitor extends MarkdownVisitor {
     }
 
     @Override
-    public void visitHardLineBreak(ParsedMarkdown md) {
+    public void visit(HardLineBreak md) {
         // Ignore
     }
 
     @Override
-    public void visitHeading(ParsedMarkdown md) {
+    public void visit(Heading md) {
         visitChildren(md, new NotionBlock("heading_" + md.getLevel()));
     }
 
     @Override
-    public void visitThematicBreak(ParsedMarkdown md) {
+    public void visit(ThematicBreak md) {
         // Ignore
     }
 
     @Override
-    public void visitIndentedCodeBlock(ParsedMarkdown md) {
+    public void visit(IndentedCodeBlock md) {
         visitChildren(md);
     }
 
     @Override
-    public void visitListItem(ParsedMarkdown md) {
+    public void visit(ListItem md) {
         visitChildren(md, new NotionBlock(this.listStack.peek()));
     }
 
     @Override
-    public void visitOrderedList(ParsedMarkdown md) { 
+    public void visit(OrderedList md) {
         this.listStack.push("numbered_list_item");
         visitChildren(md);
         this.listStack.pop();
     }
 
     @Override
-    public void visitParagraph(ParsedMarkdown md) {
+    public void visit(Paragraph md) {
         if (listStack.size() > 0) {
             visitChildren(md);
             return;
@@ -98,16 +115,16 @@ class NotionVisitor extends MarkdownVisitor {
     }
 
     @Override
-    public void visitSoftLineBreak(ParsedMarkdown md) {
+    public void visit(SoftLineBreak md) {
         // Ignore
     }
 
     @Override
-    public void visitText(ParsedMarkdown md) {
+    public void visit(Text md) {
         block.addRichText(md.getLiteral(), md.getStyle());
     }
-    
-    private void visitChildren(ParsedMarkdown md, NotionBlock block) {
+
+    private void visitChildren(MarkdownNode md, NotionBlock block) {
         NotionBlock oldBlock = this.block;
         this.block.addChild(block);
         this.block = block;

--- a/server/main/src/com/smartnote/server/format/notion/RichText.java
+++ b/server/main/src/com/smartnote/server/format/notion/RichText.java
@@ -1,0 +1,157 @@
+package com.smartnote.server.format.notion;
+
+import static com.smartnote.server.util.JSONUtil.*;
+
+import com.google.gson.JsonObject;
+import com.smartnote.server.format.Style;
+import com.smartnote.server.util.JSONObjectSerializable;
+
+/**
+ * <p>
+ * Simplified representation of a rich text object.
+ * </p>
+ * 
+ * @author Ethan Vrhel
+ * @see NotionBlock
+ */
+public final class RichText implements JSONObjectSerializable {
+    private String literal;
+    private Style style;
+
+    /**
+     * Creates a new RichText.
+     * 
+     * @param literal The literal.
+     * @param style   The style. If <code>null</code>, the default style is used.
+     */
+    public RichText(String literal, Style style) {
+        this.literal = literal;
+        this.style = style == null ? new Style() : style;
+    }
+
+    /**
+     * Creates a new RichText with the default style.
+     * 
+     * @param literal The literal.
+     */
+    public RichText(String literal) {
+        this(literal, null);
+    }
+
+    /**
+     * Creates a new RichText with an empty literal and the default style.
+     */
+    public RichText() {
+        this("");
+    }
+
+    /**
+     * Returns the literal.
+     * 
+     * @return The literal.
+     */
+    public String getLiteral() {
+        return literal;
+    }
+
+    /**
+     * Returns the style.
+     * 
+     * @return The style.
+     */
+    public Style getStyle() {
+        return style;
+    }
+
+    @Override
+    public void loadJSON(JsonObject json) {
+        this.literal = "";
+        this.style = new Style();
+
+        String type = getStringOrNull(json, "type");
+        if (!type.equals("text"))
+            return;
+
+        JsonObject textDataObject = getObjectOrNull(json, "text");
+        if (textDataObject == null)
+            return;
+
+        JsonObject annotations = getObjectOrNull(json, "annotations");
+        if (annotations != null) {
+            boolean bold = getBooleanOrFalse(annotations, "bold");
+            boolean italic = getBooleanOrFalse(annotations, "italic");
+            boolean strikethrough = getBooleanOrFalse(annotations, "strikethrough");
+            boolean underline = getBooleanOrFalse(annotations, "underline");
+            boolean code = getBooleanOrFalse(annotations, "code");
+
+            this.style = new Style(bold, italic, strikethrough, underline, code, null);
+        }
+
+        String literal = getStringOrNull(textDataObject, "content");
+        if (literal != null)
+            this.literal = literal;
+
+        String link = getStringOrNull(textDataObject, "link");
+        if (link != null)
+            this.style = this.style.withLink(link);
+    }
+
+    @Override
+    public JsonObject writeJSON(JsonObject json) {
+        json.addProperty("type", "text");
+
+        JsonObject textDataObject = new JsonObject();
+        textDataObject.addProperty("content", literal);
+
+        if (style.link() != null) {
+            // JsonObject linkObject = new JsonObject();
+            // linkObject.addProperty("url", style.link());
+            textDataObject.addProperty("link", style.link());
+        }
+
+        json.add("text", textDataObject);
+
+        // add annotations
+        JsonObject annotations = new JsonObject();
+        if (style.bold())
+            annotations.addProperty("bold", true);
+
+        if (style.italic())
+            annotations.addProperty("italic", true);
+
+        if (style.strikethrough())
+            annotations.addProperty("strikethrough", true);
+
+        if (style.underline())
+            annotations.addProperty("underline", true);
+
+        if (style.code())
+            annotations.addProperty("code", true);
+
+        if (annotations.size() > 0)
+            json.add("annotations", annotations);
+
+        return json;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null)
+            return false;
+
+        if (o instanceof RichText rt)
+            return rt.literal.equals(literal) && rt.style.equals(style);
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return literal.hashCode() + style.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "RichText[literal=" + literal + ", style=" + style + "]";
+    }
+}

--- a/server/main/src/com/smartnote/server/util/JSONUtil.java
+++ b/server/main/src/com/smartnote/server/util/JSONUtil.java
@@ -1,5 +1,6 @@
 package com.smartnote.server.util;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
@@ -19,7 +20,7 @@ public class JSONUtil {
      * does not exist or the value is not a string.
      * 
      * @param json The JsonObject.
-     * @param key The key.
+     * @param key  The key.
      * @return The string or <code>null</code>.
      */
     public static String getStringOrNull(JsonObject json, String key) {
@@ -41,7 +42,7 @@ public class JSONUtil {
      * does not exist or the value is not a string.
      * 
      * @param json The JsonObject.
-     * @param key The key.
+     * @param key  The key.
      * @return The string.
      * @throws IllegalArgumentException If the key does not exist or the value
      *                                  is not a string.
@@ -58,7 +59,7 @@ public class JSONUtil {
      * does not exist or the value is not a JsonObject.
      * 
      * @param json The JsonObject.
-     * @param key The key.
+     * @param key  The key.
      * @return The JsonObject or <code>null</code>.
      */
     public static JsonObject getObjectOrNull(JsonObject json, String key) {
@@ -75,7 +76,7 @@ public class JSONUtil {
      * does not exist or the value is not a JsonObject.
      * 
      * @param json The JsonObject.
-     * @param key The key.
+     * @param key  The key.
      * @return The JsonObject or an empty JsonObject.
      */
     public static JsonObject getObjectOrEmpty(JsonObject json, String key) {
@@ -86,11 +87,43 @@ public class JSONUtil {
     }
 
     /**
+     * Retrieve a JsonArray from a JsonObject or <code>null</code> if the key
+     * does not exist or the value is not a JsonArray.
+     * 
+     * @param json The JsonObject.
+     * @param key  The key.
+     * @return The JsonArray or <code>null</code>.
+     */
+    public static JsonArray getArrayOrNull(JsonObject json, String key) {
+        JsonElement element = json.get(key);
+        if (element == null)
+            return null;
+        if (!element.isJsonArray())
+            return null;
+        return element.getAsJsonArray();
+    }
+
+    /**
+     * Retrieve a JsonArray from a JsonObject or an empty JsonArray if the key
+     * does not exist or the value is not a JsonArray.
+     * 
+     * @param json The JsonObject.
+     * @param key  The key.
+     * @return The JsonArray or an empty JsonArray.
+     */
+    public static JsonArray getArrayOrEmpty(JsonObject json, String key) {
+        JsonArray array = getArrayOrNull(json, key);
+        if (array == null)
+            return new JsonArray();
+        return array;
+    }
+
+    /**
      * Retrieve a boolean primitive from a JsonObject or <code>false</code> if
      * the key does not exist or the value is not a boolean.
      * 
      * @param json The JsonObject.
-     * @param key The key.
+     * @param key  The key.
      * @return The boolean or <code>false</code>.
      */
     public static boolean getBooleanOrFalse(JsonObject json, String key) {
@@ -103,6 +136,30 @@ public class JSONUtil {
         if (!primitive.isBoolean())
             return false;
         return primitive.getAsBoolean();
+    }
+
+    public static int getIntOrDefault(JsonObject json, String key, int def) {
+        JsonElement element = json.get(key);
+        if (element == null)
+            return def;
+        if (!element.isJsonPrimitive())
+            return def;
+        JsonPrimitive primitive = element.getAsJsonPrimitive();
+        if (!primitive.isNumber())
+            return def;
+        return primitive.getAsInt();
+    }
+
+    public static int getIntOrException(JsonObject json, String key) throws IllegalArgumentException {
+        JsonElement element = json.get(key);
+        if (element == null)
+            throw new IllegalArgumentException(key);
+        if (!element.isJsonPrimitive())
+            throw new IllegalArgumentException(key);
+        JsonPrimitive primitive = element.getAsJsonPrimitive();
+        if (!primitive.isNumber())
+            throw new IllegalArgumentException(key);
+        return primitive.getAsInt();
     }
 
     // Prevent instantiation

--- a/server/main/test/com/smartnote/server/TestParsedMarkdown.java
+++ b/server/main/test/com/smartnote/server/TestParsedMarkdown.java
@@ -1,0 +1,265 @@
+package com.smartnote.server;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.smartnote.server.format.ParsedMarkdown;
+import com.smartnote.server.format.Style;
+import com.smartnote.server.format.nodes.BulletList;
+import com.smartnote.server.format.nodes.Document;
+import com.smartnote.server.format.nodes.FencedCodeBlock;
+import com.smartnote.server.format.nodes.Heading;
+import com.smartnote.server.format.nodes.ListItem;
+import com.smartnote.server.format.nodes.MarkdownNode;
+import com.smartnote.server.format.nodes.OrderedList;
+import com.smartnote.server.format.nodes.Paragraph;
+import com.smartnote.server.format.nodes.Text;
+import com.smartnote.testing.BaseMarkdown;
+
+public class TestParsedMarkdown extends BaseMarkdown {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    private Document getDocument(String name) {
+        ParsedMarkdown md = parseMarkdown(name);
+        assertNotNull(md);
+        Document doc = md.getDocument();
+        assertNotNull(doc);
+        return doc;
+    }
+
+    private void assertDeepEquals(MarkdownNode expected, MarkdownNode actual) {
+        assertDeepEquals(expected.writeJSON(), actual.writeJSON());
+    }
+
+    private void assertDeepEquals(JsonElement expected, JsonElement actual) {
+        assertEquals(expected.getClass(), actual.getClass());
+
+        if (expected.isJsonArray()) {
+            assertDeepEquals((JsonArray) expected, (JsonArray) actual);
+        } else if (expected.isJsonObject()) {
+            assertDeepEquals((JsonObject) expected, (JsonObject) actual);
+        } else {
+            assertEquals(expected, actual);
+        }
+    }
+
+    private void assertDeepEquals(JsonArray expected, JsonArray actual) {
+        assertEquals(expected.size(), actual.size());
+
+        for (int i = 0; i < expected.size(); i++)
+            assertDeepEquals(expected.get(i), actual.get(i));
+    }
+
+    private void assertDeepEquals(JsonObject expected, JsonObject actual) {
+        for (String key : expected.keySet()) {
+            assertNotNull(actual.get(key));
+            assertDeepEquals(expected.get(key), actual.get(key));
+        }
+    }
+
+    private List<MarkdownNode> children(MarkdownNode... children) {
+        return List.of(children);
+    }
+
+    private Text text(String literal) {
+        return new Text(literal, null);
+    }
+
+    private Text text(String literal, Style style) {
+        return new Text(literal, style);
+    }
+
+    private Paragraph paragraph(MarkdownNode... children) {
+        return new Paragraph(children(children));
+    }
+
+    private Document document(MarkdownNode... children) {
+        return new Document(children(children));
+    }
+
+    private ListItem listItem(MarkdownNode... children) {
+        return new ListItem(children(children));
+    }
+
+    private BulletList bulletList(MarkdownNode... children) {
+        return new BulletList(children(children));
+    }
+
+    private Heading heading(int level, MarkdownNode... children) {
+        return new Heading(level, children(children));
+    }
+
+    private OrderedList orderedList(int startNumber, MarkdownNode... children) {
+        return new OrderedList(startNumber, children(children));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNotDocument() {
+        String jsonString = "{\"type\":\"text\",\"literal\":\"Hello, world!\"}";
+        JsonObject json = getGson().fromJson(jsonString, JsonObject.class);
+        ParsedMarkdown.parseFromJson(json);
+    }
+
+    @Test
+    public void testBasic() {
+        // Expected
+        Paragraph paragraph = paragraph(text("Hello World!"));
+        Document expected = document(paragraph);
+
+        var doc = getDocument(BASIC_TEXT);
+
+        assertDeepEquals(expected, doc);
+    }
+
+    @Test
+    public void testBulletList() {
+        // Expected
+        Paragraph item1Paragraph = paragraph(text("Item 1"));
+        Paragraph item2Paragraph = paragraph(text("Item 2"));
+        Paragraph item3Paragraph = paragraph(text("Item 3"));
+
+        ListItem item1 = listItem(item1Paragraph);
+        ListItem item2 = listItem(item2Paragraph);
+        ListItem item3 = listItem(item3Paragraph);
+
+        BulletList bulletList = bulletList(item1, item2, item3);
+
+        Document expected = document(bulletList);
+
+        var doc = getDocument(BULLET_LIST);
+
+        assertDeepEquals(expected, doc);
+    }
+
+    @Test
+    public void testCodeBlock() {
+        // Expected
+        FencedCodeBlock code1 = new FencedCodeBlock("javascript", "// JavaScript\nconsole.log(\"Hello, World!\");\n",
+                null);
+        FencedCodeBlock code2 = new FencedCodeBlock("python", "# Python\nprint(\"Hello, World!\")\n", null);
+        FencedCodeBlock code3 = new FencedCodeBlock("c", "// C\nprintf(\"Hello, World!\\n\");\n", null);
+
+        Document expected = document(code1, code2, code3);
+
+        var doc = getDocument(CODE_BLOCK);
+
+        assertDeepEquals(expected, doc);
+    }
+
+    @Test
+    public void testHeadings() {
+        // Expected
+        Heading heading1 = heading(1, text("Heading 1"));
+        Heading heading2 = heading(2, text("Heading 2"));
+        Heading heading3 = heading(3, text("Heading 3"));
+
+        Document expected = new Document(children(heading1, heading2, heading3));
+
+        var doc = getDocument(HEADINGS);
+
+        assertDeepEquals(expected, doc);
+    }
+
+    @Test
+    public void testNestedBulletList() {
+        // Expected
+        Text item1Text = text("Item 1");
+        Text item11Text = text("Item 1.1");
+        Text item12Text = text("Item 1.2");
+
+        Text item2Text = text("Item 2");
+        Text item21Text = text("Item 2.1");
+        Text item22Text = text("Item 2.2");
+
+        ListItem item11 = listItem(paragraph(item11Text));
+        ListItem item12 = listItem(paragraph(item12Text));
+        BulletList bulletList1 = bulletList(item11, item12);
+
+        ListItem item21 = listItem(paragraph(item21Text));
+        ListItem item22 = listItem(paragraph(item22Text));
+        BulletList bulletList2 = bulletList(item21, item22);
+
+        ListItem item1 = listItem(paragraph(item1Text), bulletList1);
+        ListItem item2 = listItem(paragraph(item2Text), bulletList2);
+
+        BulletList bulletList = bulletList(item1, item2);
+
+        Document expected = document(bulletList);
+
+        var doc = getDocument(NESTED_BULLET_LIST);
+
+        assertDeepEquals(expected, doc);
+    }
+
+    @Test
+    public void testOrderedList() {
+        // Expected
+        Text item1Text = text("Item 1");
+        Text item2Text = text("Item 2");
+        Text item3Text = text("Item 3");
+
+        ListItem item1 = listItem(paragraph(item1Text));
+        ListItem item2 = listItem(paragraph(item2Text));
+        ListItem item3 = listItem(paragraph(item3Text));
+
+        Document expected = document(orderedList(1, item1, item2, item3));
+
+        var doc = getDocument(ORDERED_LIST);
+
+        assertDeepEquals(expected, doc);
+    }
+
+    @Test
+    public void testRichText() {
+        Style style = new Style();
+        List<MarkdownNode> children = new ArrayList<>();
+
+        children.add(text("Example ", style));
+        children.add(text("rich", style.withItalic()));
+        children.add(text(" ", style));
+        children.add(text("text", style.withBold()));
+        children.add(text(" with ", style));
+        children.add(text("multiple", style.withItalic()));
+        children.add(text(" ", style));
+        children.add(text("styles", style.withBold()));
+        children.add(text(" and ", style));
+        children.add(text("links", style.withLink("https://www.notion.so/")));
+        children.add(text(".", style));
+
+        Paragraph para1 = new Paragraph(children);
+
+        children.clear();
+
+        children.add(text("A second paragraph with a ", style));
+        children.add(text("link", style.withLink("https://www.notion.so/")));
+        children.add(text(" and a ", style));
+        children.add(text("second link", style.withLink("https://www.notion.so/")));
+        children.add(text(". Even some ", style));
+        children.add(text("inline code", style.withCode()));
+        children.add(text("!", style));
+
+        Paragraph para2 = new Paragraph(children);
+
+        Document expected = document(para1, para2);
+
+        var doc = getDocument(RICH_TEXT);
+
+        assertDeepEquals(expected, doc);
+    }
+}

--- a/server/scripts/src/export.py
+++ b/server/scripts/src/export.py
@@ -32,6 +32,10 @@ with open('../../private/notion_code', 'r') as f:
     code = f.read().strip()
     f.close()
 
+if len(sys.argv) > 1:
+    code = sys.argv[1]
+    print('code manually set to', code)
+
 session = None
 
 r = su.login(base_url)
@@ -70,7 +74,7 @@ remote_information = {
 
 export_options = {
     'source': resource,
-    'output': 'I specified the name in JSON',
+    #'output': 'I specified the name in JSON',
     'exporter': 'notion',
     'remote': remote_information,
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Added tests for Markdown and Notion exporters. Refactored how Markdown is parsed and stored in the server internally.

## Related Tickets & Documents

Adds tests for features added in #61 

## QA Instructions, Screenshots, Recordings

The `ParsedMarkdown` class now uses a tree structure to store the markdown rather than JSON. It still exports to the same JSON format, but the internal format is easier to work with.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No