### PR TITLE
Fix timestamp in filename when hour is 12

### DIFF
--- a/client/src/components/ExportModal.tsx
+++ b/client/src/components/ExportModal.tsx
@@ -83,7 +83,9 @@ const ExportModal = ({
 
     const now = new Date();
     const date = `${now.getFullYear()}-${padValue(now.getMonth() + 1)}-${padValue(now.getDate())}`;
-    const time = `${padValue(now.getHours() % 12)}.${padValue(now.getMinutes())}.${padValue(now.getSeconds())}${now.getHours() < 12 ? 'AM' : 'PM'}`;
+    const hour =
+      now.getHours() === 0 || now.getHours() === 12 ? 12 : now.getHours() % 12;
+    const time = `${padValue(hour)}.${padValue(now.getMinutes())}.${padValue(now.getSeconds())}${now.getHours() < 12 ? 'AM' : 'PM'}`;
     const filename = `smartnote-${date}-at-${time}.${format}`;
 
     const aTag = document.createElement('a');


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When the user exports the notes to a local file, the filename contains a timestamp. This was previously displaying 12am incorrectly, for instance `smartnote-2024-03-06-at-00.20.06AM.txt`, which I changed to now display `smartnote-2024-03-06-at-12.20.06AM.txt`.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #102 

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [X] No
- [ ] I need help with writing tests